### PR TITLE
Remove keychain if failed to log in #28

### DIFF
--- a/Sources/AppleAPI/Client.swift
+++ b/Sources/AppleAPI/Client.swift
@@ -30,7 +30,7 @@ public class Client {
     public func validateSession() -> Promise<Void> {
         return session.dataTask(.promise, with: URLRequest.olympusSession)
         .done { data, response in
-            guard 
+            guard
                 let jsonObject = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
                 jsonObject["provider"] != nil
             else { throw Error.invalidSession }
@@ -81,7 +81,7 @@ public class Client {
             case 412 where Client.authTypes.contains(responseBody.authType ?? ""):
                 throw Error.appleIDAndPrivacyAcknowledgementRequired
             default:
-                throw Error.unexpectedSignInResponse(statusCode: httpResponse.statusCode, 
+                throw Error.unexpectedSignInResponse(statusCode: httpResponse.statusCode,
                                                      message: responseBody.serviceErrors?.map { $0.description }.joined(separator: ", "))
             }
         }
@@ -108,4 +108,3 @@ public class Client {
         }
     }
 }
-

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -55,6 +55,11 @@ func login(_ username: String, password: String) -> Promise<Void> {
     return firstly { () -> Promise<Void> in
         manager.client.login(accountName: username, password: password)
     }
+    .recover { error -> Promise<Void> in
+        // remove any keychain password if we fail to log in so it doesn't try again.
+        keychain[username] = nil
+        return Promise(error: error)
+    }
     .done { _ in
         keychain[username] = password
     }


### PR DESCRIPTION
Resolves #28 

This catches any log in error with apple and removes the keychain password so that we don't try to use the keychain next time around. 