### PR TITLE
Change signing prefix, keychain service ID and application support directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ xcodes: $(SOURCES)
 sign: xcodes
 	@codesign \
 		-s "Developer ID Application: Brandon Evans (Z2R9WCWER2)" \
-		--prefix ca.brandonevans. \
+		--prefix com.robotsandpencils. \
 		"$(BUILDDIR)/release/xcodes"
 
 .PHONY: zip

--- a/Sources/XcodesKit/XcodeManager.swift
+++ b/Sources/XcodesKit/XcodeManager.swift
@@ -61,8 +61,26 @@ public final class XcodeManager {
 }
 
 extension XcodeManager {
-    private static let applicationSupportPath = Path.applicationSupport/"ca.brandonevans.xcodes"
+    private static let applicationSupportPath = Path.applicationSupport/"com.robotsandpencils.xcodes"
     private static let cacheFilePath = applicationSupportPath/"available-xcodes.json"
+
+    /// Migrates any application support files from Xcodes < v0.4 if application support files from >= v0.4 don't exist
+    public static func migrateApplicationSupportFiles() {
+        let oldApplicationSupportPath = Path.applicationSupport/"ca.brandonevans.xcodes"
+
+        if Current.files.fileExistsAtPath(oldApplicationSupportPath.string) {
+            if Current.files.fileExistsAtPath(applicationSupportPath.string) {
+                print("Removing old support files...")
+                try? Current.files.removeItem(oldApplicationSupportPath.url)
+                print("Done")
+            }
+            else {
+                print("Migrating old support files...")
+                try? Current.files.moveItem(oldApplicationSupportPath.url, applicationSupportPath.url)
+                print("Done")
+            }
+        }
+    }
 
     private func loadCachedAvailableXcodes() throws {
         let data = try Data(contentsOf: XcodeManager.cacheFilePath.url)

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -230,6 +230,8 @@ let version = Command(usage: "version") { _, _ in
     exit(0)
 }
 
+XcodeManager.migrateApplicationSupportFiles()
+
 // This is awkward, but Guaka wants a root command in order to add subcommands,
 // but then seems to want it to behave like a normal command even though it'll only ever print the help.
 // But it doesn't even print the help without the user providing the --help flag,

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -9,7 +9,7 @@ import KeychainAccess
 import AppleAPI
 
 let manager = XcodeManager()
-let keychain = Keychain(service: "ca.brandonevans.xcodes")
+let keychain = Keychain(service: "com.robotsandpencils.xcodes")
 
 let xcodesUsername = "XCODES_USERNAME"
 let xcodesPassword = "XCODES_PASSWORD"


### PR DESCRIPTION
Changes signing prefix and keychain service ID from ca.brandonevans.xcodes to com.robotsandpencils.xcodes. Also changes application support directory from Application Support/ca.brandonevans.xcodes to Application Support/com.robotsandpencils.xcodes and will migrate the data if the old directory exists and the new one doesn't. These were both done in order to finish up the move from github.com/interstateone to github.com/robotsandpencils, and I wanted to get it done before the next release is made, which uses the keychain service ID.

Testing:

- [x] `make sign`, then `code sign -dvvvv .build/release/xcodes` and look for `Identifier=com.robotsandpencils.xcodes`. This will probably fail for anyone other than me because the Makefile specifies my own dev ID cert, but if you have one of your own you could use then you can do that.
- [x] Verify that `~/Application Support/ca.brandonevans.xcodes` exists. Run `xcodes list` and verify that it's moved to `~/Application Support/com.robotsandpencils.xcodes`.
- [x] Run `xcodes update` successfully and verify that there's an application password for com.robotsandpencils.xcodes in your Keychain

Resolves #38