### PR TITLE
#38 update keychain dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
         "state": {
           "branch": null,
-          "revision": "f77a025d2682b958722b28f69e84c0dc7318df7f",
-          "version": "3.1.2"
+          "revision": "0046db4ab8fd7be31a59e57912dbb96639ad8ce9",
+          "version": "3.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/PromiseKit/Foundation.git", .upToNextMinor(from: "3.3.1")),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", .upToNextMinor(from: "1.7.5")),
         .package(url: "https://github.com/mxcl/LegibleError.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.1.2"))
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.2.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Fixes the warning on install/build from KeychainAccess

```
warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): KeychainAccess
```

Updated to 3.2 - which improves compatibility with Swift 5. 

Resolved #41 