### PR TITLE
Update SwiftSoup to 2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {
           "branch": null,
-          "revision": "11da8c685ddde2d519fad04a7daf8485bbbc773e",
-          "version": "1.7.5"
+          "revision": "aeb5b4249c273d1783a5299e05be1b26e061ea81",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/mxcl/Version.git", .upToNextMinor(from: "1.0.3")),
         .package(url: "https://github.com/mxcl/PromiseKit.git", .upToNextMinor(from: "6.8.3")),
         .package(url: "https://github.com/PromiseKit/Foundation.git", .upToNextMinor(from: "3.3.1")),
-        .package(url: "https://github.com/scinfu/SwiftSoup.git", .upToNextMinor(from: "1.7.5")),
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", .upToNextMinor(from: "2.0.0")),
         .package(url: "https://github.com/mxcl/LegibleError.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.2.0"))
     ],


### PR DESCRIPTION
Updates SwiftSoup dependency to v 2.0

This updates warnings that were visible through xcode. As well as supports Swift 5 - which should help in #31 