### PR TITLE
Updates xcodes main errors to be more user friendly

### DIFF
--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -19,17 +19,17 @@ enum XcodesError: Swift.Error, LocalizedError {
     case missingSudoerPassword
     case invalidVersion(String)
     case unavailableVersion(Version)
-    
+
     var errorDescription: String? {
         switch self {
         case .missingUsernameOrPassword:
-            return NSLocalizedString("Missing username or a password. Please try again.", comment: ".missingUsernameOrPassword")
+            return "Missing username or a password. Please try again."
         case .missingSudoerPassword:
-            return NSLocalizedString("Missing password. Please try again.", comment: ".missingSudoerPassword")
+            return "Missing password. Please try again."
         case let .invalidVersion(version):
-            return NSLocalizedString("Version \(version) does not exist.", comment: ".invalidVersion")
+            return "\(version) is not a valid version number."
         case let .unavailableVersion(version):
-            return NSLocalizedString("Could not find version \(version.xcodeDescription).", comment: ".invalidVersion")
+            return "Could not find version \(version.xcodeDescription)."
         }
     }
 }


### PR DESCRIPTION
- Updates `Error: Swift.Error` to be `XcodesError` to be a little more detailed on what error is throwing it. 
- Inherited from `LocalizedError` so that `XcodesError` can show a friendlier string. 

So instead of 
`The operation couldn’t be completed. (Error.invalidVersion("10.2.2"))`

it will show
`Version 10.2.2 does not exist`

Totally open for some better wording (perhaps longer) on those error messages. 
