### PR TITLE
Support developer.apple.com/download redesign

### DIFF
--- a/Sources/XcodesKit/Version+Xcode.swift
+++ b/Sources/XcodesKit/Version+Xcode.swift
@@ -15,7 +15,7 @@ public extension Version {
      */
     init?(xcodeVersion: String) {
         let nsrange = NSRange(xcodeVersion.startIndex..<xcodeVersion.endIndex, in: xcodeVersion)
-        let pattern = "^(Xcode )?(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d?) ?(?<prereleaseType>\\w+)? ?(?<prereleaseVersion>\\d?)"
+        let pattern = "^(Xcode )?(?<major>\\d+)\\.?(?<minor>\\d?)\\.?(?<patch>\\d?) ?(?<prereleaseType>\\w+)? ?(?<prereleaseVersion>\\d?)"
 
         guard
             let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
@@ -23,10 +23,10 @@ public extension Version {
             let majorString = match.groupNamed("major", in: xcodeVersion),
             let major = Int(majorString),
             let minorString = match.groupNamed("minor", in: xcodeVersion),
-            let minor = Int(minorString),
             let patchString = match.groupNamed("patch", in: xcodeVersion)
         else { return nil }
 
+        let minor = Int(minorString) ?? 0
         let patch = Int(patchString) ?? 0
         let prereleaseIdentifiers = [match.groupNamed("prereleaseType", in: xcodeVersion), 
                                      match.groupNamed("prereleaseVersion", in: xcodeVersion)]

--- a/Sources/XcodesKit/XcodeManager.swift
+++ b/Sources/XcodesKit/XcodeManager.swift
@@ -150,21 +150,25 @@ extension XcodeManager {
         return firstly { () -> Promise<(data: Data, response: URLResponse)> in
             client.session.dataTask(.promise, with: URLRequest.download)
         }
-        .map { (data, response) -> [Xcode] in
-            let body = String(data: data, encoding: .utf8)!
-            let document = try SwiftSoup.parse(body)
-
-            guard 
-                let versionString = try document.select("h2:containsOwn(Xcode)").first()?.text(),
-                let version = Version(xcodeVersion: versionString),
-                let path = try document.select(".direct-download[href*=xip]").first()?.attr("href"),
-                let url = URL(string: "https://developer.apple.com" + path)
-            else { return [] }
-
-            let filename = String(path.suffix(fromLast: "/"))
-
-            return [Xcode(version: version, url: url, filename: filename)]
+        .map { (data, _) -> [Xcode] in
+            try self.parsePrereleaseXcodes(from: data)
         }
+    }
+
+    func parsePrereleaseXcodes(from data: Data) throws -> [Xcode] {
+        let body = String(data: data, encoding: .utf8)!
+        let document = try SwiftSoup.parse(body)
+
+        guard 
+            let versionString = try document.select("h2:containsOwn(Xcode)").first()?.text(),
+            let version = Version(xcodeVersion: versionString),
+            let path = try document.select(".direct-download[href*=xip]").first()?.attr("href"),
+            let url = URL(string: "https://developer.apple.com" + path)
+        else { return [] }
+
+        let filename = String(path.suffix(fromLast: "/"))
+
+        return [Xcode(version: version, url: url, filename: filename)]
     }
     
     private func persistOrCleanUpResumeData<T>(at path: Path, for result: Result<T>) {

--- a/Sources/XcodesKit/XcodeManager.swift
+++ b/Sources/XcodesKit/XcodeManager.swift
@@ -155,9 +155,9 @@ extension XcodeManager {
             let document = try SwiftSoup.parse(body)
 
             guard 
-                let versionString = try document.select("span.platform-title:containsOwn(Xcode)").first()?.parent()?.text(),
+                let versionString = try document.select("h2:containsOwn(Xcode)").first()?.text(),
                 let version = Version(xcodeVersion: versionString),
-                let path = try document.select("button.direct-download[value*=xip]").first()?.val(),
+                let path = try document.select(".direct-download[href*=xip]").first()?.attr("href"),
                 let url = URL(string: "https://developer.apple.com" + path)
             else { return [] }
 

--- a/Tests/XcodesKitTests/Version+XcodeTests.swift
+++ b/Tests/XcodesKitTests/Version+XcodeTests.swift
@@ -4,6 +4,7 @@ import Version
 
 class VersionXcodeTests: XCTestCase {
     func test_InitXcodeVersion() {
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 11 beta"), Version("11.0.0-beta"))
         XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 Beta 4"), Version("10.2.0-beta.4"))
         XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 GM"), Version("10.2.0-gm"))
         XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2"), Version("10.2.0"))

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -147,4 +147,14 @@ final class XcodesKitTests: XCTestCase {
         XCTAssertNil(destination)
         XCTAssertNil(removedItemAtURL)
     }
+
+    func test_ParsePrereleaseXcodes() {
+        let url = URL(fileURLWithPath: "developer.apple.com-download-19-6-9.html", relativeTo: URL(fileURLWithPath: #file).deletingLastPathComponent())
+        let data = try! Data(contentsOf: url)
+
+        let xcodes = try! XcodeManager().parsePrereleaseXcodes(from: data)
+
+        XCTAssertEqual(xcodes.count, 1)
+        XCTAssertEqual(xcodes[0].version, Version("11.0.0-beta"))
+    }
 }

--- a/Tests/XcodesKitTests/developer.apple.com-download-19-6-9.html
+++ b/Tests/XcodesKitTests/developer.apple.com-download-19-6-9.html
@@ -1,0 +1,1040 @@
+
+
+
+<!DOCTYPE html>
+<html xmlns="https://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+
+	<meta charset="utf-8" />
+<meta name="Author" content="Apple Inc." />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<link rel="shortcut icon" href="/favicon.ico" />
+<link rel="icon" href="/favicon.ico" />
+<link rel="mask-icon" href="/apple-logo.svg" color="#333333">
+
+<link rel="stylesheet" href="/assets/styles/globalnav.css?1" type="text/css" />
+<link rel="stylesheet" href="/assets/styles/global.dist.css" type="text/css" />
+
+<script src="/assets/scripts/lib/jquery/jquery-1.11.0.min.js"></script>
+<script src="/assets/scripts/lib/jquery/jquery.retinate.js"></script>
+<script src="/assets/scripts/global.js"></script>
+<script src="/assets/scripts/global-logout.js"></script>
+
+	<link rel="stylesheet" href="https://www.apple.com/wss/fonts?family=SF+Pro&v=2" type="text/css" />
+<link rel="stylesheet" href="https://www.apple.com/wss/fonts?family=SF+Pro+Icons&v=1" type="text/css" />
+<link rel="stylesheet" href="https://www.apple.com/wss/fonts?family=SF+Mono&v=2" type="text/css" />
+<link rel="stylesheet" href="https://www.apple.com/wss/fonts?family=Apple+Icons&amp;v=1" type="text/css" />
+
+
+	<title>Beta Software - Download - Apple Developer</title>
+	<meta name="omni_page" content="Beta Software - Download - Apple Developer">
+	<meta name="Description" content="Get the latest beta versions of Xcode, iOS , macOS, tvOS, watchOS, and more." />
+
+	<link rel="stylesheet" href="/assets/styles/router-strip.css" type="text/css">
+	<link rel="stylesheet" href="/download/styles/download-v2.css" type="text/css">
+	<link rel="stylesheet" href="/download/styles/download-modal.css" type="text/css" />
+
+		
+
+		<script>
+			window.userIsMemberOfProgram = true;
+		</script>
+
+
+		<script>
+			window.userAgreementsCheck = true;
+		</script>
+
+	<script src="/assets/scripts/ds.js"></script>
+	<script src="/assets/scripts/ds.detect.js"></script>
+	<script src="/download/scripts/download-2.js?v=0"></script>
+</head>
+<body id="beta" class="bg-light">
+
+	<aside id="ac-gn-segmentbar" class="ac-gn-segmentbar" lang="en-US" dir="ltr">
+</aside>
+<input type="checkbox" id="ac-gn-menustate" class="ac-gn-menustate" />
+<nav id="ac-globalnav" class="no-js" role="navigation" aria-label="Global" data-hires="false" data-analytics-region="global nav" lang="en-US" dir="ltr" data-store-locale="us" data-store-api="/[storefront]/shop/bag/status" data-search-locale="en_US" data-search-api="/search-services/suggestions/">
+	<div class="ac-gn-content">
+		<ul class="ac-gn-header">
+			<li class="ac-gn-item ac-gn-menuicon">
+				<label class="ac-gn-menuicon-label" for="ac-gn-menustate" aria-hidden="true">
+					<span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-top">
+						<span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-top"></span>
+					</span>
+					<span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-bottom">
+						<span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-bottom"></span>
+					</span>
+				</label>
+				<a href="#ac-gn-menustate" role="button" class="ac-gn-menuanchor ac-gn-menuanchor-open" id="ac-gn-menuanchor-open">
+					<span class="ac-gn-menuanchor-label">Global Nav Open Menu</span>
+				</a>
+				<a href="#" role="button" class="ac-gn-menuanchor ac-gn-menuanchor-close" id="ac-gn-menuanchor-close">
+					<span class="ac-gn-menuanchor-label">Global Nav Close Menu</span>
+				</a>
+			</li>
+			<li class="ac-gn-item ac-gn-apple">
+				<a class="ac-gn-link ac-gn-link-apple-developer" href="/" data-analytics-title="appledeveloper home" id="ac-gn-firstfocus-small">
+					<span class="ac-gn-link-text">Apple Developer</span>
+				</a>
+			</li>
+		</ul>
+		<div class="ac-gn-search-placeholder-container" role="search">
+			<div class="ac-gn-search ac-gn-search-small">
+				<a id="ac-gn-link-search-small" class="ac-gn-link" href="/search/" data-analytics-title="search" data-analytics-click="search" data-analytics-intrapage-link aria-label="Search Developer">
+					<div class="ac-gn-search-placeholder-bar">
+						<div class="ac-gn-search-placeholder-input">
+							<div class="ac-gn-search-placeholder-input-text" aria-hidden="true">
+								<div class="ac-gn-link-search ac-gn-search-placeholder-input-icon"></div>
+								<span class="ac-gn-search-placeholder">Search Developer</span>
+							</div>
+						</div>
+						<div class="ac-gn-searchview-close ac-gn-searchview-close-small ac-gn-search-placeholder-searchview-close">
+							<span class="ac-gn-searchview-close-cancel" aria-hidden="true">Cancel</span>
+						</div>
+					</div>
+				</a>
+			</div>
+		</div>
+		<ul class="ac-gn-list">
+			<li class="ac-gn-item ac-gn-apple">
+				<a class="ac-gn-link ac-gn-link-apple-developer" href="/" data-analytics-title="appledeveloper home" id="ac-gn-firstfocus">
+					<span class="ac-gn-link-text">Apple Developer</span>
+					</a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-discover">
+				<a class="ac-gn-link ac-gn-link-discover" href="/discover/" data-analytics-title="discover">
+					<span class="ac-gn-link-text">Discover</span>
+					</a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-design">
+				<a class="ac-gn-link ac-gn-link-design" href="/design/" data-analytics-title="design">
+					<span class="ac-gn-link-text">Design</span>
+					</a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-develop">
+				<a class="ac-gn-link ac-gn-link-develop" href="/develop/" data-analytics-title="develop">
+					<span class="ac-gn-link-text">Develop</span>
+					</a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-distribute">
+				<a class="ac-gn-link ac-gn-link-distribute" href="/distribute/" data-analytics-title="distribute">
+					<span class="ac-gn-link-text">Distribute</span>
+					</a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-dsupport">
+				<a class="ac-gn-link ac-gn-link-dsupport" href="/support/" data-analytics-title="dsupport">
+					<span class="ac-gn-link-text">Support</span>
+					</a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-account">
+				<a class="ac-gn-link ac-gn-link-account" href="/account/" data-analytics-title="account">
+					<span class="ac-gn-link-text">Account</span>
+					</a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-search" role="search">
+				<a id="ac-gn-link-search" class="ac-gn-link ac-gn-link-search" href="/search/" data-analytics-title="search" data-analytics-click="search" data-analytics-intrapage-link aria-label="Search Developer"></a>
+			</li>
+		</ul>
+		<aside id="ac-gn-searchview" class="ac-gn-searchview" role="search" data-analytics-region="search">
+			<div class="ac-gn-searchview-content">
+				<div class="ac-gn-searchview-bar">
+					<div class="ac-gn-searchview-bar-wrapper">
+						<form id="ac-gn-searchform" class="ac-gn-searchform" action="/search/" method="get">
+							<div class="ac-gn-searchform-wrapper">
+								<input id="ac-gn-searchform-input" class="ac-gn-searchform-input" type="text" name="q" aria-label="Search Developer" placeholder="Search Developer" autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="true" aria-owns="quicklinks suggestions" />
+								<button id="ac-gn-searchform-submit" class="ac-gn-searchform-submit" type="submit" disabled aria-label="Submit Search"></button>
+								<button id="ac-gn-searchform-reset" class="ac-gn-searchform-reset" type="reset" disabled aria-label="Clear Search">
+										<span class="ac-gn-searchform-reset-background"></span>
+									</button>
+							</div>
+						</form>
+						<button id="ac-gn-searchview-close-small" class="ac-gn-searchview-close ac-gn-searchview-close-small" aria-label="Cancel Search">
+								<span class="ac-gn-searchview-close-cancel" aria-hidden="true">
+									Cancel
+								</span>
+							</button>
+					</div>
+				</div>
+				<aside id="ac-gn-searchresults" class="ac-gn-searchresults" data-string-quicklinks="Quick Links" data-string-suggestions="Suggested Searches" data-string-noresults=""></aside>
+			</div>
+			<button id="ac-gn-searchview-close" class="ac-gn-searchview-close" aria-label="Cancel Search">
+					<span class="ac-gn-searchview-close-wrapper">
+						<span class="ac-gn-searchview-close-left"></span>
+						<span class="ac-gn-searchview-close-right"></span>
+					</span>
+				</button>
+		</aside>
+			</div>
+</nav>
+<div class="ac-gn-blur"></div>
+<div id="ac-gn-curtain" class="ac-gn-curtain"></div>
+<div id="ac-gn-placeholder" class="ac-nav-placeholder"></div>
+<script src="/assets/scripts/ac-globalnav.built.js"></script>
+
+	<!-- metrics -->
+<script>
+    /* RSID: */
+    var s_account="awdappledeveloper"
+</script>	
+<script src="/assets/metrics/scripts/analytics.js"></script>
+<script>
+    s.pageName= AC && AC.Tracking && AC.Tracking.pageName();
+    s.channel="www.en.developer"
+    s.channel="www.download.developer";
+
+    
+    /************* DO NOT ALTER ANYTHING BELOW THIS LINE ! **************/
+    var s_code=s.t();if(s_code)document.write(s_code)
+</script>
+<!-- /metrics -->
+
+	<link rel="stylesheet" property="stylesheet" href="/assets/styles/localnav.css" type="text/css" />
+<input type="checkbox" id="localnav-menustate" class="localnav-menustate"/>
+<nav id="localnav" class="localnav localnav-scrim" data-sticky role="navigation">
+	<div class="localnav-wrapper">
+		<div class="localnav-background"></div>
+		<div class="localnav-content">
+			<h2 class="localnav-title">
+				<a href="/download/">Downloads</a>
+			</h2>
+
+			<div class="localnav-menu">
+				<a href="#localnav-menustate" class="localnav-menucta-anchor localnav-menucta-anchor-open" id="localnav-menustate-open">
+					<span class="localnav-menucta-anchor-label">Open Menu</span>
+				</a>
+				<a href="#" class="localnav-menucta-anchor localnav-menucta-anchor-close" id="localnav-menustate-close">
+					<span class="localnav-menucta-anchor-label">Close Menu</span>
+				</a>
+				<div class="localnav-menu-tray">
+					<ul class="localnav-menu-items">
+						<li class="localnav-menu-item">
+							
+								<span class="localnav-menu-link current" role="link" aria-disabled="true">Beta</span>
+							
+						</li>
+						<li class="localnav-menu-item">
+							
+								<a href="/download/release/" class="localnav-menu-link">Release</a>
+							
+						</li>
+						<li class="localnav-menu-item">
+							
+								<a href="/download/more/" class="localnav-menu-link">More</a>
+							
+						</li>
+					</ul>
+				</div>
+				<div class="localnav-actions localnav-actions">
+					<div class="localnav-action localnav-action-menucta" aria-hidden="true">
+						<label for="localnav-menustate" class="localnav-menucta">
+							<span class="localnav-menucta-chevron"></span>
+						</label>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</nav>
+<label id="localnav-curtain" for="localnav-menustate"></label>
+<script src="/assets/scripts/ac-localnav.built.js"></script>
+
+	
+	<link rel="stylesheet" href="/assets/includes/signout-nav/styles/signout-nav.css" type="text/css">
+	<nav class="signout-nav overflow">
+		<div class="grid">
+			<div class="row">
+				<ul>
+					<li>
+						<span>Brandon</span>
+						<span>Evans</span>
+					</li>
+					<li>
+						<a href="/logout/?return=%2Fdownload%2F">Sign Out</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</nav>
+
+	<main id="main" class="main" role="main">
+
+		<section class="section section-hero">
+			<div class="section-content">
+				<div class="row">
+					<div class="column large-centered large-8 medium-10 small-12 text-center">
+						<h1 class="typography-headline">Beta Software Downloads</h1>
+					</div>
+				</div>
+			</div>
+		</section>
+
+
+		<section class="section section-downloads">
+			<div class="section-content">
+				<div class="row">
+					<div class="column large-centered large-12 text-center">
+						<nav class="tabnav">
+							<ul id="tabnav-dl" class="tabnav-items inline-controls tabnav-items">
+								<li class="tabnav-item"><a href="#os" data-slide-index="0"><figure class="icon-nav icon-nav-os center"></figure>Operating Systems</a></li><!--
+								--><li class="tabnav-item"><a href="#app" data-slide-index="1" class="active"><figure class="icon-nav icon-nav-app center"></figure>Applications</a></li>
+							</ul>
+						</nav>
+					</div>
+				</div>
+				<div class="row">
+					<div class="column column-slider large-centered large-12">
+						<ul class="bxslider dltype">
+							<!-- Operating Systems Tab -->
+							<li class="os-links">
+																 <div class="row">
+									<div class="column column-banner large-12">
+										<div class="banner typography-subbody">
+											If you’re enrolled as an individual and have not agreed to the Apple Developer Program License Agreement or if you’re enrolled as an organization and your team’s Account Holder has not agreed to the Apple Developer Program License agreement, you are not permitted to use this software. Refer to the software installation guides for complete instructions.
+										</div>
+									</div>
+								</div>
+								
+									<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-macos-10-15"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>macOS Catalina 10.15 beta</h2>
+										<p>Run the macOS Developer Beta Access Utility to download the latest macOS beta. As&nbsp;new macOS betas become available you will receive a notification and can install them from the Software Update pane in System Preferences.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>19A471t</li>
+											<li></li>
+										</ul>
+									</div>
+									
+									<div class="column large-2 small-12">
+										<a href="/services-account/download?path=/WWDC_2019/macOS_10.15_Developer_Beta_Access_Utility/macOSDeveloperBetaAccessUtility.dmg" class="button direct-download">Install Profile</a>
+										<p class="typography-caption"><a href="/go/?id=macos-10.15-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								
+								<div id="ios-restore-images-iphone-new" class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								
+								<div class="row expandable">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-ios-13"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>iOS 13 beta</h2>
+										<p>This version is intended exclusively for software developers to test their apps and start adopting the new technologies in iOS. Make sure to back up your device and install only on systems you are prepared to erase if necessary.</p> 
+										
+										<p><strong>Important Note for Thrill Seekers</strong>: If you’re interested in living on the edge and trying out the great new features in iOS 13, we strongly advise waiting for the many bug fixes and refinements coming to the public beta next month.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>17A5492t</li>
+											<li></li>
+										</ul>
+
+										<h5 class="expandable-headline typography-subbody icon icon-before icon-downloadcircle">
+											<a href="#ios-restore-images-iphone-new" tabIndex="1">
+												Download Restore Images
+												<span class="typography-subbody icon icon-after icon-chevronup hide-all">Hide all</span>
+												<span class="typography-subbody icon icon-after icon-chevrondown view-all">View all</span>
+												<p>Installation requires macOS 10.15 beta or Xcode 11 beta.</p>
+											</a>
+										</h5>
+										<div class="inner">
+											<ul class="ios-list typography-subbody">
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone112iPhone116_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone XS Max, iPhone XS</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone118_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone XR</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone103iPhone106_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone X</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone_4.7_P3_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone 8, iPhone 7</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone_5.5_P3_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone 8 Plus, iPhone 7 Plus</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone_4.0_64bit_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone SE</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone_4.7_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone 6s</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPhone_5.5_13.0_17A5492t_Restore.ipsw"class="direct-download">iPhone 6s Plus</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPodtouch_13.0_17A5492t_Restore.ipsw"class="direct-download">iPod touch (7th generation)</a>
+													<p>17A5492t</p>
+												</li>
+											</ul>
+										</div>
+									</div>
+									<div class="column large-2 small-12">
+									<p class="typography-caption"><a href="/go/?id=ios-13-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								
+								<div id="ios-restore-images-ipad-new" class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								<div class="row expandable">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-ipados-13"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>iPadOS 13 beta</h2>
+										<p>This version is intended exclusively for software developers to test their apps and start adopting the new technologies in iPadOS. Make sure to back up your device and install only on systems you are prepared to erase if necessary.</p> 
+										
+										<p><strong>Important Note for Thrill Seekers</strong>: If you’re interested in living on the edge and trying out the great new features in iPadOS 13, we strongly advise waiting for the many bug fixes and refinements coming to the public beta next month.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>17A5492t</li>
+											<li></li>
+										</ul>
+
+										<h5 class="expandable-headline typography-subbody icon icon-before icon-downloadcircle">
+											<a href="#ios-restore-images-ipad-new" tabIndex="1">
+												Download Restore Images
+												<span class="typography-subbody icon icon-after icon-chevronup hide-all">Hide all</span>
+												<span class="typography-subbody icon icon-after icon-chevrondown view-all">View all</span>
+												<p>Installation requires macOS 10.15 beta or Xcode 11 beta.</p>
+											</a>
+										</h5>
+										<div class="inner">
+											<ul class="ios-list typography-subbody">
+												
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPad_Fall_2018_13.0_17A5492t_Restore.ipsw"class="direct-download">iPad Pro (11 inch), iPad Pro (12.9-inch)(3rd generation)</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPad_Pro_HFR_13.0_17A5492t_Restore.ipsw"class="direct-download">iPad Pro (10.5 inch), iPad Pro (12.9-inch)(2nd generation)</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPad_64bit_TouchID_ASTC_13.0_17A5492t_Restore.ipsw"class="direct-download">iPad (5th generation), iPad (6th generation)</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPad_Spring_2019_13.0_17A5492t_Restore.ipsw"class="direct-download">iPad mini (5th generation), iPad Air (3rd generation)</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPad_64bit_TouchID_13.0_17A5492t_Restore.ipsw"class="direct-download">iPad mini 4, iPad Air 2</a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPadPro_9.7_13.0_17A5492t_Restore.ipsw"class="direct-download">iPad Pro <span class="nowrap">(9.7‑inch)</span></a>
+													<p>17A5492t</p>
+												</li>
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/iPadPro_12.9_13.0_17A5492t_Restore.ipsw"class="direct-download">iPad Pro <span class="nowrap">(12.9‑inch)</span></a>
+													<p>17A5492t</p>
+												</li>
+											</ul>
+										</div>
+									</div>
+									<div class="column large-2 small-12">
+									<p class="typography-caption"><a href="/go/?id=iPadOS-13-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+							
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-watchos-6"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>watchOS 6 beta</h2>
+										<p>Install configuration profile directly on your device to receive OTA updates.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>17R5491t</li>
+										</ul>
+									</div>
+									<div class="column large-2 small-12">
+										
+										<a href="/services-account/download?path=/WWDC_2019/watchOS_6_beta_Configuration_Profile/watchOS_6_Beta_Profilemobileconfig.mobileconfig" class="button direct-download" data-download-type="mobileconfig">Install Profile</a>
+										<p class="typography-caption"><a href="/go/?id=watchOS-6-sdk-rn" class="more">Release Notes</a></p>
+										
+									</div>
+								</div>
+								
+								
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+							
+							<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-tvos"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>tvOS 13 beta</h2>
+										<p>Install the configuration profile directly on your device to receive OTA updates for Apple&nbsp;TV 4K or Apple&nbsp;TV HD</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>17J5485s</li>
+											<li><span>Compatibility</span>Apple TV HD or later</li>
+										</ul>
+										<div class="inner-wrap typography-subbody">
+											<h5 class="typography-subbody">Download Restore Images</h5>
+											<p>Install via iTunes.</p>
+											<ul class="tvos-list">
+												<li><a href="/services-account/download?path=/WWDC_2019/iOS_and_tvOS_IPSWs_for_Jun_3_2019_Seed/AppleTV53_13.0_17J5485s_Restore.ipsw"class="direct-download">Apple&nbsp;TV HD</a>
+													<p>17J5485s</p>
+												</li>
+											</ul>
+									</div>
+								</div>
+									
+									<div class="column large-2 small-12">
+										
+										<a href="/services-account/download?path=/WWDC_2019/tvOS_13_beta_Configuration_Profile/tvOS_13_Beta_Profile.mobileconfig" class="button direct-download" data-download-type="mobileconfig">Install Profile</a>
+										<p class="typography-caption"><a href="/go/?id=tvos-13-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+	
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-macos"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>macOS Mojave 10.14.6 beta</h2>
+										<p>Run the macOS Developer Beta Access Utility to download the latest macOS beta. As new macOS betas become available you will receive a notification and can install them from the Software Update pane in System Preferences.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>May 15, 2019</li>
+											<li><span>Build</span>18G29g</li>
+											<li></li>
+										</ul>
+									</div>
+									<div class="column large-2 small-12">
+										<a href="/services-account/download?path=/WWDC_2018/macOS_10.14_Developer_Beta_Access_Utility/macOSDeveloperBetaAccessUtility.dmg" class="button direct-download">Install Profile</a>
+										<p class="typography-caption"><a href="/go/?id=macos-10.14.6-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								<div id="ios-restore-images-iphone-old" class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								<div class="row expandable">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-ios"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>iOS 12.4 beta 3</h2>
+										<p>Install Configuration Profile directly on any iOS device and receive OTA updates.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>May 28, 2019</li>
+											<li><span>Build</span>16G5038d</li>
+											<li></li>
+										</ul>
+
+										<h5 class="expandable-headline typography-subbody icon icon-before icon-downloadcircle">
+											<a href="#ios-restore-images-iphone-old" tabIndex="1">
+												Download Restore Images
+												<span class="typography-subbody icon icon-after icon-chevronup hide-all">Hide all</span>
+												<span class="typography-subbody icon icon-after icon-chevrondown view-all">View all</span>
+												<p>Install via iTunes.</p>
+											</a>
+										</h5>
+										<div class="inner">
+											<ul class="ios-list typography-subbody">
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69815/624265B8-7E29-11E9-B41F-76A2AACA3927/iPhone11,6_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone XS Max</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69820/6230B764-7E29-11E9-BD53-74A2AACA3927/iPhone11,2_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone XS</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69834/627B51CA-7E29-11E9-A8A2-8FA2AACA3927/iPhone11,8_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone XR</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69651/62448C08-7E29-11E9-A0D9-72A2AACA3927/iPhone10,3,iPhone10,6_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone X</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69823/622696D0-7E29-11E9-A90B-6FA2AACA3927/iPhone_4.7_P3_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone 8, iPhone 7</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69891/624E925C-7E29-11E9-A4B2-71A2AACA3927/iPhone_5.5_P3_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone 8 Plus, iPhone 7 Plus</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69907/623B5AC0-7E29-11E9-9554-8CA2AACA3927/iPhone_4.0_64bit_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone SE, iPhone 5s</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69689/626810F6-7E29-11E9-BD52-8EA2AACA3927/iPhone_4.7_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone 6s, iPhone 6</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69886/625BE650-7E29-11E9-8D3F-8DA2AACA3927/iPhone_5.5_12.4_16G5038d_Restore.ipsw"class="direct-download">iPhone 6s Plus, iPhone  6 Plus</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69853/625F9E1C-7E29-11E9-91FD-7EA2AACA3927/iPad_Fall_2018_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad Pro (11 inch), iPad Pro (12.9-inch)(3rd generation)</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69704/6251451A-7E29-11E9-A017-79A2AACA3927/iPad_Pro_HFR_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad Pro (10.5 inch), iPad Pro (12.9-inch)(2nd generation)</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69831/625E3D60-7E29-11E9-B9A5-81A2AACA3927/iPad_64bit_TouchID_ASTC_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad (5th generation), iPad (6th generation)</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69895/62552752-7E29-11E9-944F-7CA2AACA3927/iPad_Spring_2019_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad mini (5th generation), iPad Air (3rd generation)</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69910/623E34DE-7E29-11E9-B4F3-85A2AACA3927/iPad_64bit_TouchID_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad mini 4, iPad Air 2, iPad mini 3</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69707/625CAFEA-7E29-11E9-9FFA-7AA2AACA3927/iPadPro_9.7_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad Pro <span class="nowrap">(9.7‑inch)</span></a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69697/626B5F68-7E29-11E9-87AD-86A2AACA3927/iPadPro_12.9_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad Pro <span class="nowrap">(12.9‑inch)</span></a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69653/62700BDA-7E29-11E9-A8F9-80A2AACA3927/iPad_64bit_12.4_16G5038d_Restore.ipsw"class="direct-download">iPad Air, iPad mini 2</a>
+													<p>16G5038d</p>
+												</li>
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-69767/625C929E-7E29-11E9-AD32-89A2AACA3927/iPodtouch_12.4_16G5038d_Restore.ipsw"class="direct-download">iPod touch (6th generation)</a>
+													<p>16G5038d</p>
+												</li>
+											</ul>
+										</div>
+									</div>
+									<div class="column large-2 small-12">
+										<a href="/services-account/download?path=/WWDC_2018/iOS_12_beta_Configuration_Profile/iOS_12_Beta_Profile.mobileconfig" class="button direct-download" data-download-type="mobileconfig">Install Profile</a>
+										<p class="typography-caption"><a href="/go/?id=ios-12.4-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+
+	
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-watchos"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>watchOS 5.3 beta 2</h2>
+										<p>Install configuration profile directly on your device to receive OTA updates.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>May 28, 2019</li>
+											<li><span>Build</span>16U5537b</li>
+										</ul>
+									</div>
+									<div class="column large-2 small-12">
+										<a href="/services-account/download?path=/WWDC_2018/watchOS_5_beta_Configuration_Profile/watchOS_5_Beta_Profile.mobileconfig" class="button direct-download" data-download-type="mobileconfig">Install Profile</a>
+										<p class="typography-caption"><a href="/go/?id=watchOS-5.3-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+				
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-os icon-tvos"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>tvOS 12.4 beta 2</h2>
+										<p>Install the configuration profile directly on your device to receive OTA updates for Apple&nbsp;TV 4K or Apple&nbsp;TV HD.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>May 28, 2019</li>
+											<li><span>Build</span>16M5537c</li>
+											<li><span>Compatibility</span>Apple TV&nbsp;HD or later</li>
+										</ul>
+										<div class="inner-wrap typography-subbody">
+											<h5 class="typography-subbody">Download Restore Images</h5>
+											<p>Install via iTunes.</p>
+											<ul class="tvos-list">
+												<li><a href="http://updates-http.cdn-apple.com/2019SpringSeed/fullrestores/041-67310/5FBA2A34-7DBA-11E9-A4AC-B9291F9811EA/AppleTV5,3_12.4_16M5537c_Restore.ipsw"class="direct-download">Apple&nbsp;TV 4K and Apple&nbsp;TV HD</a>
+													<p>16M5537c</p>
+												</li>
+											</ul>
+										</div>
+									</div>
+									<div class="column large-2 small-12">
+										<a href="/services-account/download?path=/WWDC_2018/tvOS_12_beta_Configuration_Profile/tvOS_12_Beta_Profile.mobileconfig" class="button direct-download" data-download-type="mobileconfig">Install Profile</a>
+										<p class="typography-caption"><a href="/go/?id=tvos-12.4-sdk-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+
+
+					
+			<!-- Release downloads -->	
+			
+
+							</li>
+							<!-- Applications Tab -->
+							<li class="app-links">
+																<div class="row">
+									<div class="column column-banner large-12">
+										<div class="banner typography-subbody">
+										If you’re enrolled as an individual and have not agreed to the Apple Developer Program License Agreement or if you’re enrolled as an organization and your team’s Account Holder has not agreed to the Apple Developer Program License agreement, you are not permitted to use this software.
+										</div>
+									</div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-xcode"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>Xcode 11 beta</h2>
+										<p>Xcode 11 includes everything you need to create amazing apps for all Apple platforms. Includes the latest SDKs for macOS, iOS, watchOS, and tvOS.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>11M336W</li>
+										</ul>
+									</div>
+									<div class="column large-2 small-12">
+										<p class="typography-caption"><a href="/go/?id=xcode-11-beta" class="more">Release Notes</a></p>
+										<a href="/services-account/download?path=/WWDC_2019/Xcode_11_Beta/Xcode_11_Beta.xip" class="button direct-download">Download</a>
+									</div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-reality-composer"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>Reality Composer beta</h2>
+										<p>The Reality Composer iOS app lets you easily prototype and produce AR experiences directly in AR with no prior 3D experience.  It live links to the Reality Composer Xcode tool on Mac so you can build, test, tune, and iterate on your AR experience on the device that’s best for you.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>1A68</li>
+											<li><span>Compatibility</span>iOS 13 beta</li>
+										</ul>
+									</div>
+									<div class="column large-2 small-12">
+										<button class="button register" data-agreement-id="al5kesj2" data-agreement-name="Reality Composer beta">Request</button>
+										<p class="typography-caption"></p>
+									</div>
+								</div>
+								
+									<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-testflight"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>TestFlight 2.6 beta</h2>
+										<p>TestFlight makes it easy to test beta versions of iOS, tvOS, and watchOS apps. Request to test the beta version of TestFlight for iOS and give feedback directly to Apple. iOS 13 beta is required to test the latest prerelease features.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>37</li>
+											<li><span>Compatibility</span>iOS 8 or later</li>
+										</ul>
+										</div>
+										<div class="column large-2 small-12">
+										<button class="button register" data-agreement-id="ak2lse3b" data-agreement-name="TestFlight 2.6 beta">Request</button>
+										<p class="typography-caption"><a href="/app-store-connect/whats-new/?id=testflightbeta" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+									
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-classroom-mac"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>Classroom for iPad 3.1 beta</h2>
+										<p>Classroom turns your iPad into a powerful teaching assistant, helping you guide students through a lesson, see their progress and keep them on track. With Classroom, you can easily launch the same app on every student device at the same time or launch a different app for each group of students. Classroom helps teachers focus on teaching, so students can focus on learning.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>3B3g</li>
+											<li><span>Compatibility</span>iOS 12.2 and later</li>
+										</ul>
+										</div>
+										<div class="column large-2 small-12">
+										<button class="button register" data-agreement-id="ae5jen2v" data-agreement-name="Classroom for iPad">Request</button>
+										<p class="typography-caption"><a href="/go/?id=Classroom-for-iPad-3.1-beta-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-classroom-mac"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>Classroom for Mac 2.1 beta </h2>
+										<p>Classroom turns your Mac into a powerful teaching assistant, helping you guide students through a lesson, see their progress and keep them on track. With Classroom, you can easily launch the same app on every student iPad at the same time or launch a different app for each group of students. Classroom helps teachers focus on teaching, so students can focus on learning.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>2B3d</li>
+											<li><span>Compatibility</span>macOS 10.14.4 and later</li>
+											</ul>
+											</div>
+											<div class="column large-2 small-12">
+										<button class="direct-download button" value="/services-account/download?path=/Applications/Classroom_for_Mac_2.1_beta/Classroom_for_Mac_2.1_beta.dmg">Download</button>
+										<p class="typography-caption"><a href="/go/?id=Classroom-for-Mac-2.1-beta-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-server"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>macOS Server 5.9 beta</h2>		
+										<p>macOS Server makes it easy to configure and monitor Mac, iPhone, iPad, and Apple TV devices and network storage volumes.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>19S1020b</li>
+											<li><span>Compatibility</span>macOS 10.15 beta and later</li>
+											
+										</ul>
+									</div>
+									
+									<div class="column large-2 small-12">
+										<button class="direct-download button" value="/services-account/download?path=/macOS_Server/macOS_Server_5.9_beta/macOS_Server_5.9_beta.dmg">Download</button>
+										<p class="typography-caption"><a href="/go/?id=macOS-Server-5.9-beta-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-configurator"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>Apple Configurator 2.10 beta</h2>
+										<p>Apple Configurator 2 makes it easy to deploy iPad, iPhone, iPod touch, and Apple TV devices in your school or business. Use Apple Configurator 2 to quickly configure large numbers of devices connected to your Mac via USB with the settings, apps, and data you specify for your students, employees, or customers.</p>	
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>3K13</li>
+											<li><span>Compatibility</span>macOS 10.14.6 and later</li>
+											</ul>
+											</div>	
+										<div class="column large-2 small-12">
+										<button class="direct-download button" value="/services-account/download?path=/iOS/Apple_Configurator_2.10_beta/Apple_Configurator_2.10_beta.dmg">Download</button>
+										<p class="typography-caption"><a href="/go/?id=apple-configurator-2.10-beta-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+								<div class="row">
+									<div class="column large-offset-1 large-11 small-offset-0 small-12 divider-mid"></div>
+								</div>
+								
+	
+								<div class="row">
+									<div class="column large-1 medium-2 small-12">
+										<figure class="icon-app icon-Apple-Remote-Desktop"></figure>
+									</div>
+									<div class="column large-9 medium-8 small-12">
+										<h2>Apple Remote Desktop 3.9.2 beta </h2>
+										<p>Apple Remote Desktop is the best way to manage the Mac computers on your network. Distribute software, provide real-time online help to end-users, create detailed software and hardware reports, and automate routine management tasks - all from your own Mac.</p>
+										<ul class="version typography-caption">
+											<li><span>Released</span>June 3, 2019</li>
+											<li><span>Build</span>1A25</li>
+											<li><span>Compatibility</span>macOS 10.14 and later</li>
+											</ul>
+											</div>
+											<div class="column large-2 small-12">
+										<button class="direct-download button" value="/services-account/download?path=/Applications/Apple_Remote_Desktop_3.9.2_beta/Apple_Remote_Desktop_3.9.2_beta.dmg">Download</button>
+										<p class="typography-caption"><a href="/go/?id=Apple-Remote-Desktop-3.9.2-beta-rn" class="more">Release Notes</a></p>
+									</div>
+								</div>
+								
+						
+								
+								
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</section>
+
+
+	</main>
+
+
+	<aside class="section developer-router-links">
+		<div class="section-content">
+			<div class="row">
+				<div class="column large-4 small-12">
+					<a href="/support/beta-software/install-beta/" class="block text-center">
+						<figure class="router-icon router-icon-documentation"></figure>
+						<h5>Installing Apple Beta<br />Software</h5>
+					</a>
+				</div>
+				<div class="column large-4 small-12">
+					<a href="/support/beta-software/" class="block text-center">
+						<figure class="router-icon router-icon-documentation"></figure>
+						<h5>Using Apple Beta<br />Software</h5>
+					</a>
+				</div>
+				<div class="column large-4 small-12">
+					<a href="/library/archive/technotes/tn2249/_index.html" class="block text-center">
+						<figure class="router-icon router-icon-documentation"></figure>
+						<h5>Testing Your App on<br />Beta OS Releases</h5>
+					</a>
+				</div>
+			</div>
+		</div>
+	</aside>
+
+	<section id="globalfooter-wrapper">
+		<footer id="globalfooter" role="contentinfo">
+			<nav class="footer-breadory">
+				<a href="/" class="home breadcrumbs-home"><span aria-hidden="true"></span><span class="breadcrumbs-home-label">Developer</span></a>
+				<section class="breadcrumbs">
+					<ol class="breadcrumbs-list">
+						<li>Download</li>
+					</ol>
+				</section>
+				<div id="directorynav" class="directorynav">
+	<div id="dn-cola" class="column">
+		<h3><a href="/discover/">Discover</a></h3>
+		<ul>
+			<li><a href="/macos/">macOS</a></li>
+			<li><a href="/ios/">iOS</a></li>
+			<li><a href="/watchos/">watchOS</a></li>
+			<li><a href="/tvos/">tvOS</a></li>
+			<li><a href="/safari/">Safari and Web</a></li>
+			<li><a href="/games/">Games</a></li>
+			<li><a href="/business/">Business</a></li>
+			<li><a href="/education/">Education</a></li>
+			<li><a href="/wwdc/">WWDC</a></li>
+		</ul>
+	</div>
+	<div id="dn-colb" class="column">
+		<h3><a href="/design/">Design</a></h3>
+		<ul>
+			<li><a href="/design/human-interface-guidelines/">Human Interface Guidelines</a></li>
+			<li><a href="/design/resources/">Resources</a></li>
+			<li><a href="/videos/design/">Videos</a></li>
+			<li><a href="/design/awards/">Apple Design Awards</a></li>
+			<li><a href="/fonts/">Fonts</a></li>
+			<li><a href="/accessibility/">Accessibility</a></li>
+			<li><a href="/internationalization/">Internationalization</a></li>
+			<li><a href="/accessories/">Accessories</a></li>
+
+		</ul>
+	</div>
+	<div id="dn-colc" class="column">
+		<h3><a href="/develop/">Develop</a></h3>
+		<ul>
+			<li><a href="/xcode/">Xcode</a></li>
+			<li><a href="/swift/">Swift</a></li>
+			<li><a href="/swift-playgrounds/">Swift Playgrounds</a></li>
+			<li><a href="/testflight/">TestFlight</a></li>
+			<li><a href="/documentation/">Documentation</a></li>
+			<li><a href="/videos/">Videos</a></li>
+			<li><a href="/download/">Downloads</a></li>
+		</ul>
+	</div>
+	<div id="dn-cold" class="column">
+		<h3><a href="/distribute/">Distribute</a></h3>
+		<ul>
+			<li><a href="/programs/">Developer Program</a></li>
+			<li><a href="/app-store/">App Store</a></li>
+			<li><a href="/app-store/review/">App Review</a></li>
+			<li><a href="/macos/distribution/">Mac Software</a></li>
+			<li><a href="/business/distribute/">Apps for Business</a></li>
+			<li><a href="/safari/extensions/">Safari Extensions</a></li>
+			<li><a href="/app-store/marketing/guidelines/">Marketing Resources</a></li>
+			<li><a href="/softwarelicensing/">Trademark Licensing</a></li>
+		</ul>
+	</div>
+	<div id="dn-cole" class="column">
+		<h3><a href="/support/">Support</a></h3>
+		<ul>
+			<li><a href="/support/articles/">Articles</a></li>
+			<li><a href="https://forums.developer.apple.com">Developer Forums</a></li>
+			<li><a href="/bug-reporting/">Feedback &amp; Bug&nbsp;Reporting</a></li>
+			<li><a href="/system-status/">System Status</a></li>
+			<li><a href="/contact/">Contact Us</a></li>
+		</ul>
+		<h3><a href="/account/">Account</a></h3>
+		<ul>
+			<li><a href="/account/ios/certificate/">Certificates, Identifiers &amp; Profiles</a></li>
+			<li><a href="https://appstoreconnect.apple.com/">App Store Connect</a></li>
+		</ul>
+	</div>
+</div>
+
+			</nav>
+			<div class="ac-gf-footer-legal">
+	<div class="ac-gf-footer-news">To view the latest developer news, visit <a href="/news/">News and Updates</a>.</div>
+	<div class="ac-gf-footer-legal-copyright">Copyright ©  2019 Apple Inc. All rights reserved.</div>
+	<div class="ac-gf-footer-legal-links">
+		<a href="https://www.apple.com/legal/internet-services/terms/site.html" class="first">Terms of Use</a>
+		<a href="https://www.apple.com/legal/privacy/en-ww/">Privacy Policy</a>
+		<a href="/terms/">License Agreements</a>
+	</div>
+	<div class="ac-gf-footer-language-links">
+		<a href="/cn/" lang="zh" class="first">简体中文</a>
+		<a href="/jp/" lang="ja">日本語</a>
+		<a href="/kr/" lang="ko">한국어</a>
+	</div>
+</div>
+
+		</footer>
+	</section>
+
+	<script src="/assets/scripts/lib/jquery/jquery.bxslider.min.js"></script>
+	<script src="/download/scripts/slider.js"></script>
+	<script src="/download/scripts/expand.js"></script>
+	<section class="modal takeover inactive" aria-hidden="true">
+
+			<!-- View dimmer -->
+			<section class="dimmer inactive" aria-hidden="true"></section>
+
+			<!-- View -->
+			<div class="view text-center" role="dialog">
+				<div>
+					<p>Thank you for your interest in <span class="modal-agreement-name nowrap"></span>. We’ve received your request. If accepted, you'll receive an email from TestFlight.</p>
+				</div>
+				<div class="buttons margin-top-small">
+					<a class="anchor-button ok-dismiss">OK</a>
+				</div>
+			</div>
+
+		</section>
+</body>
+</html>


### PR DESCRIPTION
Closes #48.

I'm currently seeing Xcode 11 fail the `spctl` Gatekeeper check, and this PR is not intending to address that. See #50.