### PR TITLE
Improve Gatekeeper error message

### DIFF
--- a/Sources/XcodesKit/Models.swift
+++ b/Sources/XcodesKit/Models.swift
@@ -2,7 +2,7 @@ import Foundation
 import Path
 import Version
 
-public struct InstalledXcode {
+public struct InstalledXcode: Equatable {
     public let path: Path
     public let bundleVersion: Version
 

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -238,7 +238,17 @@ let install = Command(usage: "install <version>", flags: [urlFlag]) { flags, arg
         exit(0)
     }
     .catch { error in
-        print(error.legibleLocalizedDescription)
+        switch error {
+        case XcodeInstaller.Error.failedSecurityAssessment(let xcode, let output):
+            print("""
+                  Xcode \(xcode.bundleVersion) failed its security assessment with the following output:
+                  \(output)
+                  It remains installed at \(xcode.path) if you wish to use it anyways.
+                  """)
+        default:
+            print(error.legibleLocalizedDescription)
+        }
+
         exit(1)
     }
 

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -44,8 +44,9 @@ final class XcodesKitTests: XCTestCase {
         Current.shell.spctlAssess = { _ in return Promise(error: Process.PMKError.execution(process: Process(), standardOutput: nil, standardError: nil)) }
 
         let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock")
+        let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-0.0.0.app")!)!
         installer.installArchivedXcode(xcode, at: URL(fileURLWithPath: "/Xcode-0.0.0.xip"), passwordInput: { Promise.value("") })
-            .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.failedSecurityAssessment) }
+            .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.failedSecurityAssessment(xcode: installedXcode, output: "")) }
     }
 
     func test_InstallArchivedXcode_VerifySigningCertificateFails_Throws() {
@@ -77,14 +78,16 @@ final class XcodesKitTests: XCTestCase {
     func test_VerifySecurityAssessment_Fails() {
         Current.shell.spctlAssess = { _ in return Promise(error: Process.PMKError.execution(process: Process(), standardOutput: nil, standardError: nil)) }
 
-        installer.verifySecurityAssessment(of: URL(fileURLWithPath: "/"))
+        let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-0.0.0.app")!)!
+        installer.verifySecurityAssessment(of: installedXcode)
             .tap { result in XCTAssertFalse(result.isFulfilled) }
     }
 
     func test_VerifySecurityAssessment_Succeeds() {
         Current.shell.spctlAssess = { _ in return Promise.value((0, "", "")) }
 
-        installer.verifySecurityAssessment(of: URL(fileURLWithPath: "/"))
+        let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-0.0.0.app")!)!
+        installer.verifySecurityAssessment(of: installedXcode)
             .tap { result in XCTAssertTrue(result.isFulfilled) }
     }
 


### PR DESCRIPTION
Xcode 11 beta 1 fails the Gatekeeper check (`spctl`). This PR improves the error message shown from:

`The operation couldn’t be completed. (Error.failedSecurityAssessment)`

to:

```
Xcode 11.0.0 failed its security assessment with the following output:

/Applications/Xcode-11.0.0-beta.app: rejected (invalid destination for symbolic link in bundle)

It remains installed at /Applications/Xcode-11.0.0-beta.app if you wish to use it anyways.
```

Resolves #50.