### PR TITLE
Refactor to better define boundaries

### DIFF
--- a/Sources/XcodesKit/Configuration.swift
+++ b/Sources/XcodesKit/Configuration.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Path
+
+public struct Configuration: Codable {
+    public var defaultUsername: String?
+
+    public init() {
+        self.defaultUsername = nil
+    }
+
+    public mutating func load() throws {
+        let data = try Data(contentsOf: Path.configurationFile.url)
+        self = try JSONDecoder().decode(Configuration.self, from: data)
+    }
+
+    public func save() throws {
+        let data = try JSONEncoder().encode(self)
+        try FileManager.default.createDirectory(at: Path.configurationFile.url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try data.write(to: Path.configurationFile.url)
+    }
+}
+

--- a/Sources/XcodesKit/Models.swift
+++ b/Sources/XcodesKit/Models.swift
@@ -51,7 +51,3 @@ public struct InfoPlist: Decodable {
         case bundleShortVersion = "CFBundleShortVersionString"
     }
 }
-
-public struct Configuration: Codable {
-    public let defaultUsername: String?
-}

--- a/Sources/XcodesKit/Path+.swift
+++ b/Sources/XcodesKit/Path+.swift
@@ -1,0 +1,8 @@
+import Path
+
+extension Path {
+    static let oldXcodesApplicationSupport = Path.applicationSupport/"ca.brandonevans.xcodes"
+    static let xcodesApplicationSupport = Path.applicationSupport/"com.robotsandpencils.xcodes"
+    static let cacheFile = xcodesApplicationSupport/"available-xcodes.json"
+    static let configurationFile = xcodesApplicationSupport/"configuration.json"
+}

--- a/Sources/XcodesKit/URLSession+Promise.swift
+++ b/Sources/XcodesKit/URLSession+Promise.swift
@@ -1,0 +1,47 @@
+import Foundation
+import PromiseKit
+import PMKFoundation
+
+extension URLSession {
+    /**
+     - Parameter convertible: A URL or URLRequest.
+     - Parameter saveLocation: A URL to move the downloaded file to after it completes. Apple deletes the temporary file immediately after the underyling completion handler returns.
+     - Parameter resumeData: Data describing the state of a previously cancelled or failed download task. See the Discussion section for `downloadTask(withResumeData:completionHandler:)` https://developer.apple.com/documentation/foundation/urlsession/1411598-downloadtask#
+
+     - Returns: Tuple containing a Progress object for the task and a promise containing the save location and response.
+
+     - Note: We do not create the destination directory for you, because we move the file with FileManager.moveItem which changes its behavior depending on the directory status of the URL you provide. So create your own directory first!
+     */
+    public func downloadTask(_: PMKNamespacer, with convertible: URLRequestConvertible, to saveLocation: URL, resumingWith resumeData: Data?) -> (progress: Progress, promise: Promise<(saveLocation: URL, response: URLResponse)>) {
+        var progress: Progress!
+
+        let promise = Promise<(saveLocation: URL, response: URLResponse)> { seal in
+            let completionHandler = { (temporaryURL: URL?, response: URLResponse?, error: Error?) in
+                if let error = error {
+                    seal.reject(error)
+                } else if let response = response, let temporaryURL = temporaryURL {
+                    do {
+                        try FileManager.default.moveItem(at: temporaryURL, to: saveLocation)
+                        seal.fulfill((saveLocation, response))
+                    } catch {
+                        seal.reject(error)
+                    }
+                } else {
+                    seal.reject(PMKError.invalidCallingConvention)
+                }
+            }
+            
+            let task: URLSessionDownloadTask
+            if let resumeData = resumeData {
+                task = downloadTask(withResumeData: resumeData, completionHandler: completionHandler)
+            }
+            else {
+                task = downloadTask(with: convertible.pmkRequest, completionHandler: completionHandler)
+            }
+            progress = task.progress
+            task.resume()
+        }
+
+        return (progress, promise)
+    }
+}

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -6,7 +6,7 @@ import SwiftSoup
 import AppleAPI
 
 /// Provides lists of available and installed Xcodes
-public final class XcodeManager {
+public final class XcodeList {
     private let client: AppleAPI.Client
 
     public init(client: AppleAPI.Client) {
@@ -50,7 +50,7 @@ public final class XcodeManager {
     }
 }
 
-extension XcodeManager {
+extension XcodeList {
     /// Migrates any application support files from Xcodes < v0.4 if application support files from >= v0.4 don't exist
     public static func migrateApplicationSupportFiles() {
         if Current.files.fileExistsAtPath(Path.oldXcodesApplicationSupport.string) {
@@ -93,7 +93,7 @@ extension XcodeManager {
     }
 }
 
-extension XcodeManager {
+extension XcodeList {
     private func releasedXcodes() -> Promise<[Xcode]> {
         return firstly { () -> Promise<(data: Data, response: URLResponse)> in
             client.session.dataTask(.promise, with: URLRequest.downloads)

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -12,7 +12,6 @@ public final class XcodeList {
     public init(client: AppleAPI.Client) {
         self.client = client
         try? loadCachedAvailableXcodes()
-        try? loadConfiguration()
     }
 
     public var installedXcodes: [InstalledXcode] {
@@ -28,8 +27,6 @@ public final class XcodeList {
 
     public private(set) var availableXcodes: [Xcode] = []
 
-    public private(set) var configuration = Configuration(defaultUsername: nil)
-
     public var shouldUpdate: Bool {
         return availableXcodes.isEmpty
     }
@@ -42,11 +39,6 @@ public final class XcodeList {
                 try? self.cacheAvailableXcodes(xcodes)
                 return xcodes
             }
-    }
-
-    public func saveUsername(_ username: String) {
-        self.configuration = Configuration(defaultUsername: username)
-        try? saveConfiguration(self.configuration)
     }
 }
 
@@ -78,18 +70,6 @@ extension XcodeList {
         try FileManager.default.createDirectory(at: Path.cacheFile.url.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
         try data.write(to: Path.cacheFile.url)
-    }
-
-    private func loadConfiguration() throws {
-        let data = try Data(contentsOf: Path.configurationFile.url)
-        self.configuration = try JSONDecoder().decode(Configuration.self, from: data)
-    }
-
-    private func saveConfiguration(_ configuration: Configuration) throws {
-        let data = try JSONEncoder().encode(configuration)
-        try FileManager.default.createDirectory(at: Path.configurationFile.url.deletingLastPathComponent(),
-                                                withIntermediateDirectories: true)
-        try data.write(to: Path.configurationFile.url)
     }
 }
 

--- a/Sources/XcodesKit/XcodeManager.swift
+++ b/Sources/XcodesKit/XcodeManager.swift
@@ -2,7 +2,6 @@ import Foundation
 import Path
 import Version
 import PromiseKit
-import PMKFoundation
 import SwiftSoup
 import AppleAPI
 
@@ -146,40 +145,5 @@ extension XcodeManager {
         let filename = String(path.suffix(fromLast: "/"))
 
         return [Xcode(version: version, url: url, filename: filename)]
-    }
-}
-
-extension URLSession {
-    public func downloadTask(_: PMKNamespacer, with convertible: URLRequestConvertible, to saveLocation: URL, resumingWith resumeData: Data?) -> (progress: Progress, promise: Promise<(saveLocation: URL, response: URLResponse)>) {
-        var progress: Progress!
-
-        let promise = Promise<(saveLocation: URL, response: URLResponse)> { seal in
-            let completionHandler = { (temporaryURL: URL?, response: URLResponse?, error: Error?) in
-                if let error = error {
-                    seal.reject(error)
-                } else if let response = response, let temporaryURL = temporaryURL {
-                    do {
-                        try FileManager.default.moveItem(at: temporaryURL, to: saveLocation)
-                        seal.fulfill((saveLocation, response))
-                    } catch {
-                        seal.reject(error)
-                    }
-                } else {
-                    seal.reject(PMKError.invalidCallingConvention)
-                }
-            }
-            
-            let task: URLSessionDownloadTask
-            if let resumeData = resumeData {
-                task = downloadTask(withResumeData: resumeData, completionHandler: completionHandler)
-            }
-            else {
-                task = downloadTask(with: convertible.pmkRequest, completionHandler: completionHandler)
-            }
-            progress = task.progress
-            task.resume()
-        }
-
-        return (progress, promise)
     }
 }

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -12,6 +12,8 @@ let client = AppleAPI.Client()
 let installer = XcodeInstaller(client: client)
 let xcodeList = XcodeList(client: client)
 let keychain = Keychain(service: "com.robotsandpencils.xcodes")
+var configuration = Configuration()
+try? configuration.load()
 
 let xcodesUsername = "XCODES_USERNAME"
 let xcodesPassword = "XCODES_PASSWORD"
@@ -67,7 +69,7 @@ func findUsername() -> String? {
     if let username = env(xcodesUsername) {
         return username
     }
-    else if let username = xcodeList.configuration.defaultUsername {
+    else if let username = configuration.defaultUsername {
         return username
     }
     return nil
@@ -104,8 +106,9 @@ func login(_ username: String, password: String) -> Promise<Void> {
     .done { _ in
         keychain[username] = password
 
-        if xcodeList.configuration.defaultUsername != username {
-            xcodeList.saveUsername(username)
+        if configuration.defaultUsername != username {
+            configuration.defaultUsername = username
+            try? configuration.save()
         }
     }
 }

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -100,7 +100,7 @@ final class XcodesKitTests: XCTestCase {
         var removedItemAtURL: URL?
         Current.files.removeItem = { removedItemAtURL = $0 } 
 
-        XcodeManager.migrateApplicationSupportFiles()
+        XcodeList.migrateApplicationSupportFiles()
 
         XCTAssertNil(source)
         XCTAssertNil(destination)
@@ -115,7 +115,7 @@ final class XcodesKitTests: XCTestCase {
         var removedItemAtURL: URL?
         Current.files.removeItem = { removedItemAtURL = $0 } 
 
-        XcodeManager.migrateApplicationSupportFiles()
+        XcodeList.migrateApplicationSupportFiles()
 
         XCTAssertEqual(source, Path.applicationSupport.join("ca.brandonevans.xcodes").url)
         XCTAssertEqual(destination, Path.applicationSupport.join("com.robotsandpencils.xcodes").url)
@@ -130,7 +130,7 @@ final class XcodesKitTests: XCTestCase {
         var removedItemAtURL: URL?
         Current.files.removeItem = { removedItemAtURL = $0 } 
 
-        XcodeManager.migrateApplicationSupportFiles()
+        XcodeList.migrateApplicationSupportFiles()
 
         XCTAssertNil(source)
         XCTAssertNil(destination)
@@ -145,7 +145,7 @@ final class XcodesKitTests: XCTestCase {
         var removedItemAtURL: URL?
         Current.files.removeItem = { removedItemAtURL = $0 } 
 
-        XcodeManager.migrateApplicationSupportFiles()
+        XcodeList.migrateApplicationSupportFiles()
 
         XCTAssertNil(source)
         XCTAssertNil(destination)
@@ -156,7 +156,7 @@ final class XcodesKitTests: XCTestCase {
         let url = URL(fileURLWithPath: "developer.apple.com-download-19-6-9.html", relativeTo: URL(fileURLWithPath: #file).deletingLastPathComponent())
         let data = try! Data(contentsOf: url)
 
-        let xcodes = try! XcodeManager().parsePrereleaseXcodes(from: data)
+        let xcodes = try! XcodeList(client: AppleAPI.Client()).parsePrereleaseXcodes(from: data)
 
         XCTAssertEqual(xcodes.count, 1)
         XCTAssertEqual(xcodes[0].version, Version("11.0.0-beta"))

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -3,6 +3,7 @@ import Version
 import PromiseKit
 import PMKFoundation
 import Path
+import AppleAPI
 @testable import XcodesKit
 
 final class XcodesKitTests: XCTestCase {
@@ -16,7 +17,7 @@ final class XcodesKitTests: XCTestCase {
         Current = .mock
     }
 
-    let installer = XcodeInstaller()
+    let installer = XcodeInstaller(client: AppleAPI.Client())
 
     func test_ParseCertificateInfo_Succeeds() throws {
         let sampleRawInfo = """


### PR DESCRIPTION
XcodeManager had a lot of responsibilities and a poor name, so this PR intends to fix that. XcodeManager is now XcodeList, and provides arrays of available and installed Xcodes. This better differentiates it from XcodeInstaller, which focuses on the download and install process. The Configuration type and some extensions have been moved into more appropriate places too.

**How to test:**

It should be sufficient to make sure that the `xcodes list`, `xcodes installed`, and `xcodes update` commands continue to work as expected. You can run these with `swift run COMMAND`.