### PR TITLE
Move XIPs to Trash instead of immediately deleting them

### DIFF
--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -55,6 +55,13 @@ struct Files {
     func removeItem(at URL: URL) throws {
         try removeItem(URL)
     }
+
+    var trashItem: (URL) throws -> URL = { try FileManager.default.trashItem(at: $0) }
+
+    @discardableResult
+    func trashItem(at URL: URL) throws -> URL {
+        return try trashItem(URL)
+    }
     
     var createFile: (String, Data?, [FileAttributeKey: Any]?) -> Bool = { FileManager.default.createFile(atPath: $0, contents: $1, attributes: $2) }
     

--- a/Sources/XcodesKit/FileManager+.swift
+++ b/Sources/XcodesKit/FileManager+.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension FileManager {
+    /**
+     Moves an item to the trash.
+     
+     This implementation exists only to make the existing method more idiomatic by returning the resulting URL instead of setting the value on an inout argument.
+
+     FB6735133: FileManager.trashItem(at:resultingItemURL:) is not an idiomatic Swift API
+     */
+    @discardableResult
+    func trashItem(at url: URL) throws -> URL {
+        var resultingItemURL: NSURL!
+        try trashItem(at: url, resultingItemURL: &resultingItemURL)
+        return resultingItemURL as URL
+    }
+}

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -39,7 +39,7 @@ public final class XcodeInstaller {
         }
     }
 
-    public func installArchivedXcode(_ xcode: Xcode, at url: URL, passwordInput: @escaping () -> Promise<String>) -> Promise<Void> {
+    public func installArchivedXcode(_ xcode: Xcode, at url: URL, archiveTrashed: @escaping (URL) -> Void, passwordInput: @escaping () -> Promise<String>) -> Promise<Void> {
         return firstly { () -> Promise<InstalledXcode> in
             let destinationURL = Path.root.join("Applications").join("Xcode-\(xcode.version.descriptionWithoutBuildMetadata).app").url
             switch url.pathExtension {
@@ -59,7 +59,8 @@ public final class XcodeInstaller {
             }
         }
         .then { xcode -> Promise<InstalledXcode> in
-            try Current.files.removeItem(at: url)
+            try Current.files.trashItem(at: url)
+            archiveTrashed(url)
 
             return when(fulfilled: self.verifySecurityAssessment(of: xcode),
                                    self.verifySigningCertificate(of: xcode.path.url))

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -233,7 +233,9 @@ let install = Command(usage: "install <version>", flags: [urlFlag]) { flags, arg
         }
     }
     .then { xcode, url -> Promise<Void> in
-        return installer.installArchivedXcode(xcode, at: url, passwordInput: { () -> Promise<String> in
+        return installer.installArchivedXcode(xcode, at: url, archiveTrashed: { archiveURL in
+            print("Xcode archive \(url.lastPathComponent) has been moved to the Trash.")
+        }, passwordInput: { () -> Promise<String> in
             return Promise { seal in
                 print("xcodes requires superuser privileges in order to setup some parts of Xcode.")
                 guard let password = readSecureLine(prompt: "Password: ") else { seal.reject(XcodesError.missingSudoerPassword); return }

--- a/Tests/XcodesKitTests/Environment+Mock.swift
+++ b/Tests/XcodesKitTests/Environment+Mock.swift
@@ -46,6 +46,7 @@ extension Files {
             }
         },
         removeItem: { _ in },
+        trashItem: { _ in return URL(fileURLWithPath: "\(NSHomeDirectory())/.Trash") },
         createFile: { _, _, _ in return true }
     )
 }


### PR DESCRIPTION
This changes the installation behaviour to move XIPs to the Trash after Xcode has been installed to /Applications instead of immediately deleting them. This more closely matches the steps users take when downloading Xcode XIPs manually, but more importantly it provides a way to recover from installation issues without downloading the (very large) XIPs all over again.

```
$ .build/release/xcodes install 11 beta 4
Downloading Xcode 11.0.0-beta.4+11M374r: 195%
Xcode archive Xcode-11.0.0-beta.4+11M374r.xip has been moved to the Trash.
Xcode 11.0.0-beta.4+11M374r failed its security assessment with the following output:

/Applications/Xcode-11.0.0-beta.4.app: rejected (invalid destination for symbolic link in bundle)

It remains installed at /Applications/Xcode-11.0.0-beta.4.app if you wish to use it anyways.
```

Closes #56 