### PR TITLE
Sign with hardened runtime and timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ sign: xcodes
 		--sign "Developer ID Application: Robots and Pencils Inc. (PBH8V487HB)" \
 		--prefix com.robotsandpencils. \
 		--options runtime \
+		--timestamp \
 		"$(BUILDDIR)/release/xcodes"
 
 .PHONY: zip

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ sign: xcodes
 	@codesign \
 		-s "Developer ID Application: Robots and Pencils Inc. (PBH8V487HB)" \
 		--prefix com.robotsandpencils. \
+		--options runtime \
 		"$(BUILDDIR)/release/xcodes"
 
 .PHONY: zip

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@ all: xcodes
 .PHONY: xcodes
 xcodes: $(SOURCES)
 	@swift build \
-		-c release \
+		--configuration release \
 		--disable-sandbox \
 		--build-path "$(BUILDDIR)" \
 
 .PHONY: sign
 sign: xcodes
 	@codesign \
-		-s "Developer ID Application: Robots and Pencils Inc. (PBH8V487HB)" \
+		--sign "Developer ID Application: Robots and Pencils Inc. (PBH8V487HB)" \
 		--prefix com.robotsandpencils. \
 		--options runtime \
 		"$(BUILDDIR)/release/xcodes"
@@ -31,7 +31,7 @@ sign: xcodes
 .PHONY: zip
 zip: sign
 	@rm xcodes.zip 2> /dev/null || true
-	@zip -j xcodes.zip "$(BUILDDIR)/release/xcodes"
+	@zip --junk-paths xcodes.zip "$(BUILDDIR)/release/xcodes"
 	@open -R xcodes.zip
 
 # E.g.


### PR DESCRIPTION
Two primary changes:

- Code signing now ensures the binary is run with the [hardened runtime](), making it less likely that xcodes could be exploited for malicious purposes on a users computer by restricting what it can do. These new restrictions shouldn't affect xcodes' features, and during testing it worked as before.
- Signing with a timestamp is a [requirement for notarization](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution#3087727). It's currently [not possible](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/customizing_the_notarization_workflow#3087720) (FB6885253) to notarize a standalone executable, but I'd like to be ready to support this if/when it becomes possible.

I also made a small change to use long flag names in some of the commands in the Makefile, for clarity.

---
```sh
make clean

make sign

.build/release/xcodes update   
Enter the code:
# ...
11.0 Beta 5 (11M382q)

.build/release/xcodes install 11 beta 5
Downloading Xcode 11.0.0-beta.5+11M382q: 100%
xcodes requires superuser privileges in order to setup some parts of Xcode.
Password: 

ls /Applications | grep Xcode
# ...
Xcode-11.0.0-beta.5.app
```
---

Resolves #58 