### PR TITLE
Improve GM seed version parsing and descriptions

### DIFF
--- a/Tests/XcodesKitTests/Version+XcodeTests.swift
+++ b/Tests/XcodesKitTests/Version+XcodeTests.swift
@@ -4,15 +4,28 @@ import Version
 
 class VersionXcodeTests: XCTestCase {
     func test_InitXcodeVersion() {
-        XCTAssertEqual(Version(xcodeVersion: "Xcode 11 beta"), Version("11.0.0-beta"))
-        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 Beta 4"), Version("10.2.0-beta.4"))
-        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 GM"), Version("10.2.0-gm"))
-        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2"), Version("10.2.0"))
-        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2.1"), Version("10.2.1"))
-        XCTAssertEqual(Version(xcodeVersion: "10.2 Beta 4"), Version("10.2.0-beta.4"))
-        XCTAssertEqual(Version(xcodeVersion: "10.2 GM"), Version("10.2.0-gm"))
-        XCTAssertEqual(Version(xcodeVersion: "10.2"), Version("10.2.0"))
-        XCTAssertEqual(Version(xcodeVersion: "10.2.1"), Version("10.2.1"))
+        XCTAssertEqual(Version(xcodeVersion: "10.2"),                 Version(major: 10, minor: 2, patch: 0))
+        XCTAssertEqual(Version(xcodeVersion: "10.2.1"),               Version(major: 10, minor: 2, patch: 1))
+        XCTAssertEqual(Version(xcodeVersion: "10.2 Beta 4"),          Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["beta", "4"]))
+        XCTAssertEqual(Version(xcodeVersion: "10.2 GM"),              Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm"]))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2"),           Version(major: 10, minor: 2, patch: 0))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2.1"),         Version(major: 10, minor: 2, patch: 1))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 11 beta"),        Version(major: 11, minor: 0, patch: 0, prereleaseIdentifiers: ["beta"]))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 Beta 4"),    Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["beta", "4"]))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 GM"),        Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm"]))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 GM seed"),   Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed"]))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 GM seed 1"), Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed", "1"]))
+        XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 GM seed 2"), Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed", "2"]))
+    }
+
+    func test_XcodeDescription() {
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0).xcodeDescription,                                          "10.2")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 1).xcodeDescription,                                          "10.2.1")
+        XCTAssertEqual(Version(major: 11, minor: 0, patch: 0, prereleaseIdentifiers: ["beta"]).xcodeDescription,         "11.0 Beta")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["beta", "4"]).xcodeDescription,    "10.2 Beta 4")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm"]).xcodeDescription,           "10.2 GM")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed"]).xcodeDescription,      "10.2 GM Seed")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed", "1"]).xcodeDescription, "10.2 GM Seed 1")
     }
 
     func test_Equivalence() {


### PR DESCRIPTION
The important change here is to the regular expression used to parse version strings so that it supports multi-word prerelease identifiers like "GM seed". It treats all words as one identifier, like "gm-seed", followed by any prerelease version identifiers like "4" in "gm seed 4".

Another small change is to capitalize "gm" as "GM" instead of "Gm".

**Testing:**

You should try to install 11 GM seed 2 while you have GM seed 1 installed at `/Applications/Xcode-11.0.0-gm.app`, or `/Applications/Xcode-11.0.0-gm-seed.1.app`

(Note I had GM seed 1 installed already as `/Applications/Xcode-11.0.0-gm.app`, which is the `11.0 GM (11A419c) (Installed)` in the list below. It's GM prerelease identifier is taken from the filename, which is why it isn't `11.0 GM Seed 1 (11A419c) (Installed)`.)

```
$ swift build

$ .build/debug/xcodes update

$ .build/debug/xcodes list
# ...
11.0 Beta 5 (11M382q) (Installed)
11.0 Beta 7 (11M392r) (Installed)
11.0 GM (11A419c) (Installed)
11.0 GM Seed 2 (11A420a)

$ .build/debug/xcodes install 11 gm seed 2
# ...

$ .build/debug/xcodes list
# ...
11.0 Beta 5 (11M382q) (Installed)
11.0 Beta 7 (11M392r) (Installed)
11.0 GM (11A419c) (Installed)
11.0 GM Seed 2 (11A420a) (Installed)
```

Resolves #69.