### PR TITLE
Consolidate versions from both download sites

### DIFF
--- a/Sources/XcodesKit/Version+.swift
+++ b/Sources/XcodesKit/Version+.swift
@@ -10,20 +10,29 @@ public extension Version {
 
     /// If release versions, don't compare build metadata because that's not provided in the /downloads/more list
     /// if beta versions, compare build metadata because it's available in versions.plist
-    func isEquivalentForDeterminingIfInstalled(to other: Version) -> Bool {
+    func isEquivalentForDeterminingIfInstalled(toInstalled installed: Version) -> Bool {
         let isBeta = !prereleaseIdentifiers.isEmpty
-        let otherIsBeta = !other.prereleaseIdentifiers.isEmpty
+        let otherIsBeta = !installed.prereleaseIdentifiers.isEmpty
 
         if isBeta && otherIsBeta {
-            return major == other.major && 
-                   minor == other.minor &&
-                   patch == other.patch &&
-                   buildMetadataIdentifiers.map { $0.lowercased() } == other.buildMetadataIdentifiers.map { $0.lowercased() }
+            if buildMetadataIdentifiers.isEmpty {
+                return major == installed.major &&
+                       minor == installed.minor &&
+                       patch == installed.patch &&
+                       prereleaseIdentifiers == installed.prereleaseIdentifiers
+            }
+            else {
+                return major == installed.major &&
+                       minor == installed.minor &&
+                       patch == installed.patch &&
+                       prereleaseIdentifiers == installed.prereleaseIdentifiers &&
+                       buildMetadataIdentifiers.map { $0.lowercased() } == installed.buildMetadataIdentifiers.map { $0.lowercased() }
+            }
         }
         else if !isBeta && !otherIsBeta {
-            return major == other.major && 
-                   minor == other.minor &&
-                   patch == other.patch
+            return major == installed.major && 
+                   minor == installed.minor &&
+                   patch == installed.patch
         }
 
         return false

--- a/Tests/XcodesKitTests/Version+XcodeTests.swift
+++ b/Tests/XcodesKitTests/Version+XcodeTests.swift
@@ -29,8 +29,8 @@ class VersionXcodeTests: XCTestCase {
     }
 
     func test_Equivalence() {
-        XCTAssertTrue(Version("10.2.1")!.isEquivalentForDeterminingIfInstalled(to: Version("10.2.1+abcdef")!))
-        XCTAssertFalse(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(to: Version("10.2.1-beta+abcdef")!))
-        XCTAssertTrue(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(to: Version("10.2.1-beta+QWERTY")!))
+        XCTAssertTrue(Version("10.2.1")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1+abcdef")!))
+        XCTAssertFalse(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1-beta+abcdef")!))
+        XCTAssertTrue(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1-beta+QWERTY")!))
     }
 }


### PR DESCRIPTION
Starting with Xcode 11 beta 6, developer.apple.com/download and developer.apple.com/download/more both list (some) pre-release versions of Xcode. Previously, pre-release versions only appeared on developer.apple.com/download. /download/more doesn't include build numbers, so we trust that if the version number and prerelease identifiers are the same as one on /download then they're the same build. If an Xcode version is listed on both sites then we prefer the one on /download because the build metadata is used later to compare against installed Xcodes.

Because pre-release versions that are installed also have build metadata, but this won't be the case for pre-release versions listed on /download/more, we also need to replace versions that are available with the installed ones with build metadata before printing them.

Resolves #67

**Testing**

Before:
```
❯ swift run xcodes update | tail -n15
[13/13] Linking ./.build/x86_64-apple-macosx/debug/xcodes
10.2
10.2.1 (Installed)
10.3
11.0 Beta (11M336w) (Installed)
11.0 Beta 2 (11M337n) (Installed)
11.0 Beta 3 (11M362v) (Installed)
11.0 Beta 4 (11M374r) (Installed)
11.0 Beta 5 (11M382q) (Installed)
11.0 Beta 6 (11M392q) (Installed)
11.0 Beta 7 (11M392r) (Installed)
11.0 GM Seed 1 (11A419c) (Installed)
11.0 GM Seed 2 (11A420a) (Installed)
11.0 # <---
11.0 # <--- These are Xcode 11 pre-release versions on /download/more
11.0 # <--- 
```

After:

```
❯ swift run xcodes update | tail -n15
[3/3] Linking ./.build/x86_64-apple-macosx/debug/xcodes
9.4.1
10.0
10.1 (Installed)
10.2
10.2.1 (Installed)
10.3
11.0 Beta (11M336w) (Installed)
11.0 Beta 2 (11M337n) (Installed)
11.0 Beta 3 (11M362v) (Installed)
11.0 Beta 4 (11M374r) (Installed)
11.0 Beta 5 (11M382q) (Installed)
11.0 Beta 6 (11M392q) (Installed)
11.0 Beta 7 (11M392r) (Installed)
11.0 GM Seed 1 (11A419c) (Installed)
11.0 GM Seed 2 (11A420a) (Installed)
# Note that the versions listed on /downloads/more are no longer listed twice
```