### PR TITLE
Automate notarization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ zip: sign
 	@open -R xcodes.zip
 
 # E.g.
+# make notarize USERNAME="test@example.com" PASSWORD="@keychain:altool" ASC_PROVIDER=MyOrg
+.PHONY: notarize
+notarize: zip
+	./notarize.sh "$(USERNAME)" "$(PASSWORD)" "$(ASC_PROVIDER)" xcodes.zip
+
+# E.g.
 # make bottle VERSION=0.4.0
 .PHONY: bottle
 bottle: sign

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If that occurs, it means you need to select a version of Xcode. You can do this 
 
 ## Usage
 
-E.g. `xcodes install 10.1`
+E.g. `xcodes install 11`
 
 You'll then be prompted to enter your Apple ID username and password. You can also provide these with the `XCODES_USERNAME` and `XCODES_PASSWORD` environment variables.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Manage the Xcodes installed on your Mac
 brew install robotsandpencils/made/xcodes
 ```
 
-These are Developer ID-signed release builds and don't require Xcode to already be installed in order to use.
+These are Developer ID-signed and notarized release builds and don't require Xcode to already be installed in order to use.
 
 **Other methods:**
 

--- a/notarize.sh
+++ b/notarize.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# notarize.sh
+#
+# E.g. ./notarize.sh "test@example.com" "@keychain:altool" MyOrg xcodes.zip
+#
+# Adapted from https://github.com/keybase/client/blob/46f5df0aa64ff19198ba7b044bbb7cd907c0be9f/packaging/desktop/package_darwin.sh
+
+username="$1"
+password="$2"
+asc_provider="$3"
+file="$4"
+
+echo "Uploading to notarization service"
+
+uuid=$(xcrun altool \
+    --notarize-app \
+    --primary-bundle-id "com.robotsandpencils.xcodes.zip" \
+    --username "$username" \
+    --password "$password" \
+    --asc-provider "$asc_provider" \
+    --file "$file" 2>&1 | \
+    grep 'RequestUUID' | \
+    awk '{ print $3 }')
+
+echo "Successfully uploaded to notarization service, polling for result: $uuid"
+
+sleep 15
+  while :
+  do
+    fullstatus=$(xcrun altool \
+        --notarization-info "$uuid" \
+        --username "$username" \
+        --password "$password" \
+        --asc-provider "$asc_provider" 2>&1)
+    status=$(echo "$fullstatus" | grep 'Status\:' | awk '{ print $2 }')
+    if [ "$status" = "success" ]; then
+      echo "Notarization success"
+      exit 0
+    elif [ "$status" = "in" ]; then
+      echo "Notarization still in progress, sleeping for 15 seconds and trying again"
+      sleep 15
+    else
+      echo "Notarization failed, full status below"
+      echo "$fullstatus"
+      exit 1
+    fi
+  done


### PR DESCRIPTION
This adds a makefile directive and script that notarizes the zip file that was already being created. I've already notarized existing releases back to 0.7.0, which you can test by running this command: `spctl -a -vvv -t install $(which xcodes) 2>&1 | grep Notarized`. You should see the output "source=Notarized Developer ID" if you have version 0.7.0 or later installed.

**Testing:**

You'll need to be in our ASC team. I'm not sure if you need a specific role. You'll also need to know the ASC provider value for your account if it's a member of more than one team, which is explained [here](https://indiestack.com/2019/09/notarization-provider-ids/). You could also just sort of take my word for it for now since I'm the only person making releases (😬), but if you want to make sure this works and have issues trying then let me know.

```
$ make clean
$ make notarize USERNAME="your Apple ID" PASSWORD="your password" ASC_PROVIDER="your ASC provider ID"
# build output...
./notarize.sh "your Apple ID" "your password" "your ASC provider ID" xcodes.zip
Uploading to notarization service
Successfully uploaded to notarization service, polling for result: 81CC8B3E-13FF-44BA-89D0-F23E84FF7B1C
Notarization still in progress, sleeping for 15 seconds and trying again
Notarization still in progress, sleeping for 15 seconds and trying again
Notarization still in progress, sleeping for 15 seconds and trying again
Notarization still in progress, sleeping for 15 seconds and trying again
Notarization still in progress, sleeping for 15 seconds and trying again
Notarization success
```

Resolves #59 

(I also updated the example command in the README to install Xcode 11 since it's been released now.)