### PR TITLE
Improve output for errors from underlying shell commands

### DIFF
--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -19,7 +19,7 @@ try? configuration.load()
 let xcodesUsername = "XCODES_USERNAME"
 let xcodesPassword = "XCODES_PASSWORD"
 
-enum XcodesError: Swift.Error, LocalizedError {
+enum XcodesError: LocalizedError {
     case missingUsernameOrPassword
     case missingSudoerPassword
     case invalidVersion(String)
@@ -271,11 +271,10 @@ let install = Command(usage: "install <version>", flags: [urlFlag]) { flags, arg
     }
     .catch { error in
         switch error {
-        case XcodeInstaller.Error.failedSecurityAssessment(let xcode, let output):
+        case Process.PMKError.execution(let process, let standardOutput, let standardError):
             print("""
-                  Xcode \(xcode.version) failed its security assessment with the following output:
-                  \(output)
-                  It remains installed at \(xcode.path) if you wish to use it anyways.
+                  Failed executing: `\(process)` (\(process.terminationStatus))
+                  \([standardOutput, standardError].compactMap { $0 }.joined(separator: "\n"))
                   """)
         default:
             print(error.legibleLocalizedDescription)

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -89,7 +89,7 @@ final class XcodesKitTests: XCTestCase {
 
         let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock")
         installer.installArchivedXcode(xcode, at: URL(fileURLWithPath: "/Xcode-0.0.0.xip"), archiveTrashed: { _ in }, passwordInput: { Promise.value("") })
-            .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.codesignVerifyFailed) }
+            .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.codesignVerifyFailed(output: "")) }
     }
 
     func test_InstallArchivedXcode_VerifySigningCertificateDoesntMatch_Throws() {
@@ -97,7 +97,7 @@ final class XcodesKitTests: XCTestCase {
 
         let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock")
         installer.installArchivedXcode(xcode, at: URL(fileURLWithPath: "/Xcode-0.0.0.xip"), archiveTrashed: { _ in }, passwordInput: { Promise.value("") })
-            .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.codesignVerifyFailed) }
+            .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.unexpectedCodeSigningIdentity(identifier: "", certificateAuthority: [])) }
     }
 
     func test_InstallArchivedXcode_TrashesXIPWhenFinished() {

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -56,6 +56,7 @@ final class XcodesKitTests: XCTestCase {
                 XCTAssertEqual(value, Path.applicationSupport.join("com.robotsandpencils.xcodes").join("Xcode-0.0.0.xip").url)
                 XCTAssertNil(xcodeDownloadURL)
             }
+            .cauterize()
     }
 
     func test_DownloadOrUseExistingArchive_DownloadsArchive() {
@@ -73,6 +74,7 @@ final class XcodesKitTests: XCTestCase {
                 XCTAssertEqual(value, Path.applicationSupport.join("com.robotsandpencils.xcodes").join("Xcode-0.0.0.xip").url)
                 XCTAssertEqual(xcodeDownloadURL, URL(string: "https://apple.com/xcode.xip")!)
             }
+            .cauterize()
     }
 
     func test_InstallArchivedXcode_SecurityAssessmentFails_Throws() {
@@ -111,6 +113,7 @@ final class XcodesKitTests: XCTestCase {
         let xipURL = URL(fileURLWithPath: "/Xcode-0.0.0.xip")
         installer.installArchivedXcode(xcode, at: xipURL, archiveTrashed: { _ in }, passwordInput: { Promise.value("") })
             .ensure { XCTAssertEqual(trashedItemAtURL, xipURL) }
+            .cauterize()
     }
 
     func test_UninstallXcode_TrashesXcode() {
@@ -123,6 +126,7 @@ final class XcodesKitTests: XCTestCase {
         let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-0.0.0.app")!)!
         installer.uninstallXcode(installedXcode)
             .ensure { XCTAssertEqual(trashedItemAtURL, installedXcode.path.url) }
+            .cauterize()
     }
 
     func test_VerifySecurityAssessment_Fails() {
@@ -131,6 +135,7 @@ final class XcodesKitTests: XCTestCase {
         let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-0.0.0.app")!)!
         installer.verifySecurityAssessment(of: installedXcode)
             .tap { result in XCTAssertFalse(result.isFulfilled) }
+            .cauterize()
     }
 
     func test_VerifySecurityAssessment_Succeeds() {
@@ -139,6 +144,7 @@ final class XcodesKitTests: XCTestCase {
         let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-0.0.0.app")!)!
         installer.verifySecurityAssessment(of: installedXcode)
             .tap { result in XCTAssertTrue(result.isFulfilled) }
+            .cauterize()
     }
 
     func test_MigrateApplicationSupport_NoSupportFiles() {


### PR DESCRIPTION
When shell commands failed a helpful error message wasn't always provided to the user. We've had a bunch of users fail during the unxip step because they don't have enough disk space, and while the xip tool does normally output this failure reason it wasn't being passed along by Xcode's.

This change improves some specific XcodeInstaller.Error cases and their error messages. Not all Current.shell command failures are caught and turned into XcodeInstaller.Error, though, so this also improves the fallback behaviour by printing all of the output from Process.PMKError.execution, which was omitted by default.

Testing:

```sh
# Create an empty .xip that will fail
touch test.xip

# On master
git checkout master

swift run xcodes install 11 --url ./test.xip
[3/3] Linking ./.build/x86_64-apple-macosx/debug/xcodes
Failed executing: `/usr/bin/xip --expand /Users/brandon/Projects/xcodes/test.xip` (1).

# On this branch
git checkout -b interstateone-65-output-command-errors master
git pull https://github.com/interstateone/xcodes.git 65-output-command-errors

swift run xcodes install 11 --url ./test.xip
[3/3] Linking ./.build/x86_64-apple-macosx/debug/xcodes
Failed executing: `/usr/bin/xip --expand /Users/brandon/Projects/xcodes/test.xip` (1)

xip: error: The archive “test.xip” is damaged and can’t be expanded.

```

Resolves #65.