### PR TITLE
Improve command documentation

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcodes.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcodes.xcscheme
@@ -125,6 +125,10 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "install 11 beta 5"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "install --help"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ If that occurs, it means you need to select a version of Xcode. You can do this 
 
 ## Usage
 
-E.g. `xcodes install 11`
+```
+xcodes install 10.2.1
+xcodes install 11 Beta 7
+xcodes install 11.2 GM seed
+```
 
 You'll then be prompted to enter your Apple ID username and password. You can also provide these with the `XCODES_USERNAME` and `XCODES_PASSWORD` environment variables.
 
@@ -64,12 +68,12 @@ After successfully authenticating, xcodes will save your Apple ID password into 
 
 ### Commands
 
-- `list`: Lists the versions of Xcode available to download
-- `install <version>`: Downloads and installs a version of Xcode
-- `installed`: Lists the versions of Xcodes that are installed in /Applications on your computer
-- `uninstall <version>`: Uninstalls an installed version of Xcode
-- `update`: Updates the list of available versions of Xcode
-- `version`: Prints the xcodes version
+- `install <version>`: Download and install a specific version of Xcode
+- `installed`: List the versions of Xcode that are installed
+- `list`: List all versions of Xcode that are available to install
+- `uninstall <version>`: Uninstall a specific version of Xcode
+- `update`: Update the list of available versions of Xcode
+- `version`: Print the version number of xcodes itself
 
 ## Development
 

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -169,7 +169,8 @@ func updateAndPrint() {
     RunLoop.current.run()
 }
 
-let installed = Command(usage: "installed") { _, _ in
+let installed = Command(usage: "installed",
+                        shortMessage: "List the versions of Xcode that are installed") { _, _ in
     xcodeList
         .installedXcodes
         .map { $0.version }
@@ -177,7 +178,8 @@ let installed = Command(usage: "installed") { _, _ in
         .forEach { print($0) }
 }
 
-let list = Command(usage: "list") { _, _ in
+let list = Command(usage: "list",
+                   shortMessage: "List all versions of Xcode that are available to install") { _, _ in
     if xcodeList.shouldUpdate {
         updateAndPrint()
     }
@@ -186,7 +188,8 @@ let list = Command(usage: "list") { _, _ in
     }
 }
 
-let update = Command(usage: "update") { _, _ in
+let update = Command(usage: "update",
+                     shortMessage: "Update the list of available versions of Xcode") { _, _ in
     updateAndPrint()
 }
 
@@ -234,8 +237,16 @@ func versionFromXcodeVersionFile() -> Version? {
     return version
 }
 
-let urlFlag = Flag(longName: "url", type: String.self, description: "Local path or HTTP(S) URL (currently unsupported) of Xcode .dmg or .xip.")
-let install = Command(usage: "install <version>", flags: [urlFlag]) { flags, args in
+let urlFlag = Flag(longName: "url", type: String.self, description: "Local path to Xcode .xip")
+let install = Command(usage: "install <version>",
+                      shortMessage: "Download and install a specific version of Xcode",
+                      flags: [urlFlag],
+                      example: """
+                               xcodes install 10.2.1
+                               xcodes install 11 Beta 7
+                               xcodes install 11.2 GM seed
+                               xcodes install 9.0 --url ~/Archive/Xcode_9.xip
+                               """) { flags, args in
     firstly { () -> Promise<(Xcode, URL)> in
         let versionString = args.joined(separator: " ")
         guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
@@ -286,7 +297,9 @@ let install = Command(usage: "install <version>", flags: [urlFlag]) { flags, arg
     RunLoop.current.run()
 }
 
-let uninstall = Command(usage: "uninstall <version>") { _, args in
+let uninstall = Command(usage: "uninstall <version>",
+                        shortMessage: "Uninstall a specific version of Xcode",
+                        example: "xcodes uninstall 10.2.1") { _, args in
     firstly { () -> Promise<(InstalledXcode, URL)> in
         let versionString = args.joined(separator: " ")
         guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
@@ -311,7 +324,8 @@ let uninstall = Command(usage: "uninstall <version>") { _, args in
     RunLoop.current.run()
 }
 
-let version = Command(usage: "version") { _, _ in
+let version = Command(usage: "version",
+                      shortMessage: "Print the version number of xcodes itself") { _, _ in
     print(XcodesKit.version)
     exit(0)
 }


### PR DESCRIPTION
It was previously not clear how to specify versions of Xcode to install. The current version argument parsing is sort of incidentally a little fuzzy, and so there are sometimes different ways to specify a single pre-release version like "11.2.1 GM Seed", such as "11.2.1GM Seed". This change adds examples to the command help and to the project README in order to give examples of install commands for pre-release versions. I don't think this is totally sufficient and there is more to be done, but it's a first step.

Resolves #80