### PR TITLE
Update Apple auth URLs

### DIFF
--- a/Sources/AppleAPI/URLRequest+Apple.swift
+++ b/Sources/AppleAPI/URLRequest+Apple.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 extension URL {
-    static let itcServiceKey = URL(string: "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com")!
+    static let itcServiceKey = URL(string: "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com")!
     static let signIn = URL(string: "https://idmsa.apple.com/appleauth/auth/signin")!
     static let authOptions = URL(string: "https://idmsa.apple.com/appleauth/auth")!
     static let submitSecurityCode = URL(string: "https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode")!
     static let trust = URL(string: "https://idmsa.apple.com/appleauth/auth/2sv/trust")!
-    static let olympusSession = URL(string: "https://olympus.itunes.apple.com/v1/session")!
+    static let olympusSession = URL(string: "https://appstoreconnect.apple.com/olympus/v1/session")!
 }
 
 extension URLRequest {


### PR DESCRIPTION
The URLs we were using were originally from the xcode-install project and had been working up until today (2019/11/12). These URLs [were updated](https://github.com/fastlane/fastlane/pull/14509) in that project (actually in fastlane, which it uses for auth) about 7 months ago but I didn't notice this. I started to look in a web inspector while signing in to developer.apple.com and saw that the Olympus session URL changed. [Dave DeLong noted](https://github.com/RobotsAndPencils/xcodes/issues/83#issuecomment-553207943) that a slightly different URL worked for the iTC service key, which is also what [xcinfo uses](https://github.com/xcodereleases/xcinfo/blob/e51f022db3584be884b5d10d8b161ac26dbbee0b/Sources/OlympUs/OlympUs.swift#L213).

**Testing**

1. Delete the `com.robotsandpencils.xcodes` keychain item
1. `swift run xcodes update` should complete by printing out all the available Xcode versions which as of today should end with `11.2.1`

Resolves #83 