### PR TITLE
Ignore malformed Xcode app bundles

### DIFF
--- a/Sources/XcodesKit/Entry+.swift
+++ b/Sources/XcodesKit/Entry+.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Path
+
+extension Entry {
+    var isAppBundle: Bool {
+        kind == .directory &&
+        path.extension == "app" &&
+        !path.isSymlink
+    }
+
+    var infoPlist: InfoPlist? {
+        let infoPlistPath = path.join("Contents").join("Info.plist")
+        guard
+            let infoPlistData = try? Data(contentsOf: infoPlistPath.url),
+            let infoPlist = try? PropertyListDecoder().decode(InfoPlist.self, from: infoPlistData)
+        else { return nil }
+
+        return infoPlist
+    }
+}

--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -101,14 +101,10 @@ public struct Files {
     public var installedXcodes = XcodesKit.installedXcodes
 }
 private func installedXcodes() -> [InstalledXcode] {
-    let results = try! Path.root.join("Applications").ls().filter { entry in
-        guard entry.kind == .directory && entry.path.extension == "app" && !entry.path.isSymlink else { return false }
-        let infoPlistPath = entry.path.join("Contents").join("Info.plist")
-        let infoPlist = try! PropertyListDecoder().decode(InfoPlist.self, from: try! Data(contentsOf: infoPlistPath.url))
-        return infoPlist.bundleID == "com.apple.dt.Xcode"
-    }
-    let installedXcodes = results.map { $0.path }.compactMap(InstalledXcode.init)
-    return installedXcodes
+    ((try? Path.root.join("Applications").ls()) ?? [])
+        .filter { $0.isAppBundle && $0.infoPlist?.bundleID == "com.apple.dt.Xcode" }
+        .map { $0.path }
+        .compactMap(InstalledXcode.init)
 }
 
 public struct Network {


### PR DESCRIPTION
This changes Files.installed Xcodes to ignore app bundles that don't contain Info.plist files at the expected location instead of crashing. This change doesn't include a test to verify the new behaviour because the Entry type in the Path library doesn't have an accessible initializer, which is required to construct some test data without creating what I thought would be too many workarounds for testing's sake.

Manual test steps:

1. Create a directory in /Applications with a unique name like `Xcode.app` or `Xcode-12.app`.
1. `make`
1. `.build/release/xcodes list` should print the list of available and installed Xcodes and not crash

Closes #87