### PR TITLE
Add install flags for --latest and --latest-prerelease

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/nsomar/Guaka.git",
         "state": {
           "branch": null,
-          "revision": "90c03a9e4c894808a8882a16ccf56743b4b2d40c",
-          "version": "0.4.0"
+          "revision": "6fb29b2378166a30d72120980e1c099c664598de",
+          "version": "0.4.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/getGuaka/StringScanner.git",
         "state": {
           "branch": null,
-          "revision": "39f9b77e37c69ab6fec14aadf79a066468ce63e3",
-          "version": "0.4.0"
+          "revision": "de1685ad202cb586d626ed52d6de904dd34189f3",
+          "version": "0.4.1"
         }
       },
       {

--- a/Sources/XcodesKit/DateFormatter+.swift
+++ b/Sources/XcodesKit/DateFormatter+.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension DateFormatter {
+    /// Date format used in JSON returned from `URL.downloads`
+    static let downloadsDateModified: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd/yy HH:mm"
+        return formatter
+    }()
+
+    /// Date format used in HTML returned from `URL.download`
+    static let downloadsReleaseDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d, yyyy"
+        return formatter
+    }()
+}

--- a/Sources/XcodesKit/Foundation.swift
+++ b/Sources/XcodesKit/Foundation.swift
@@ -20,3 +20,9 @@ public extension NumberFormatter {
         return string(from: number as! NSNumber)
     }
 }
+
+extension Sequence {
+    func sorted<Value: Comparable>(_ keyPath: KeyPath<Element, Value>) -> [Element] {
+        sorted(by: { $0[keyPath: keyPath] < $1[keyPath: keyPath] })
+    }
+}

--- a/Sources/XcodesKit/Models.swift
+++ b/Sources/XcodesKit/Models.swift
@@ -44,9 +44,6 @@ public struct Xcode: Codable {
     public let url: URL
     public let filename: String
     public let releaseDate: Date?
-    
-    var isPrerelease: Bool { version.prereleaseIdentifiers.isEmpty == false }
-    var isNotPrerelease: Bool { version.prereleaseIdentifiers.isEmpty == true }
 
     public init(version: Version, url: URL, filename: String, releaseDate: Date?) {
         self.version =  version

--- a/Sources/XcodesKit/Models.swift
+++ b/Sources/XcodesKit/Models.swift
@@ -43,14 +43,16 @@ public struct Xcode: Codable {
     public let version: Version
     public let url: URL
     public let filename: String
+    public let releaseDate: Date?
     
     var isPrerelease: Bool { version.prereleaseIdentifiers.isEmpty == false }
     var isNotPrerelease: Bool { version.prereleaseIdentifiers.isEmpty == true }
 
-    public init(version: Version, url: URL, filename: String) {
+    public init(version: Version, url: URL, filename: String, releaseDate: Date?) {
         self.version =  version
         self.url = url
         self.filename = filename
+        self.releaseDate = releaseDate
     }
 }
 
@@ -61,6 +63,7 @@ struct Downloads: Codable {
 public struct Download: Codable {
     public let name: String
     public let files: [File]
+    public let dateModified: Date
 
     public struct File: Codable {
         public let remotePath: String

--- a/Sources/XcodesKit/Models.swift
+++ b/Sources/XcodesKit/Models.swift
@@ -43,6 +43,9 @@ public struct Xcode: Codable {
     public let version: Version
     public let url: URL
     public let filename: String
+    
+    var isPrerelease: Bool { version.prereleaseIdentifiers.isEmpty == false }
+    var isNotPrerelease: Bool { version.prereleaseIdentifiers.isEmpty == true }
 
     public init(version: Version, url: URL, filename: String) {
         self.version =  version

--- a/Sources/XcodesKit/Version+.swift
+++ b/Sources/XcodesKit/Version+.swift
@@ -45,4 +45,7 @@ public extension Version {
         }
         return base
     }
+
+    var isPrerelease: Bool { prereleaseIdentifiers.isEmpty == false }
+    var isNotPrerelease: Bool { prereleaseIdentifiers.isEmpty == true }
 }

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -170,7 +170,7 @@ public final class XcodeInstaller {
                 guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
                     throw Error.invalidVersion(versionString)
                 }
-                let xcode = Xcode(version: version, url: path.url, filename: String(path.string.suffix(fromLast: "/")))
+                let xcode = Xcode(version: version, url: path.url, filename: String(path.string.suffix(fromLast: "/")), releaseDate: nil)
                 return Promise.value((xcode, path.url))
             case .version(let versionString):
                 guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -18,6 +18,8 @@ public final class XcodeInstaller {
         case unsupportedFileFormat(extension: String)
         case missingSudoerPassword
         case unavailableVersion(Version)
+        case noNonPrereleaseVersionAvailable
+        case noPrereleaseVersionAvailable
         case missingUsernameOrPassword
         case versionAlreadyInstalled(InstalledXcode)
         case invalidVersion(String)
@@ -54,6 +56,10 @@ public final class XcodeInstaller {
                 return "Missing password. Please try again."
             case let .unavailableVersion(version):
                 return "Could not find version \(version.xcodeDescription)."
+            case .noNonPrereleaseVersionAvailable:
+                return "No non-prerelease versions available."
+            case .noPrereleaseVersionAvailable:
+                return "No prerelease versions available."
             case .missingUsernameOrPassword:
                 return "Missing username or a password. Please try again."
             case let .versionAlreadyInstalled(installedXcode):
@@ -117,23 +123,62 @@ public final class XcodeInstaller {
         self.configuration = configuration
         self.xcodeList = xcodeList
     }
+    
+    public enum InstallationType {
+        case version(String)
+        case url(String, Path)
+        case latest
+        case latestPrerelease
+    }
 
-    public func install(_ versionString: String, _ urlString: String?) -> Promise<Void> {
+    public func install(_ installationType: InstallationType) -> Promise<Void> {
         return firstly { () -> Promise<(Xcode, URL)> in
-            guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
-                throw Error.invalidVersion(versionString)
-            }
+            switch installationType {
+            case .latest:
+                Current.logging.log("Updating...")
+                
+                return update()
+                    .then { availableXcodes -> Promise<(Xcode, URL)> in
+                        guard let latestNonPrereleaseXcode = availableXcodes.filter(\.isNotPrerelease).sorted(\.version).last else {
+                            throw Error.noNonPrereleaseVersionAvailable
+                        }
+                        Current.logging.log("Latest non-prerelease version available is \(latestNonPrereleaseXcode.version.xcodeDescription)")
+                        
+                        if let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: latestNonPrereleaseXcode.version) }) {
+                            throw Error.versionAlreadyInstalled(installedXcode)
+                        }
 
-            if let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: version) }) {
-                throw Error.versionAlreadyInstalled(installedXcode)
-            }
-
-            if let urlString = urlString {
-                let url = URL(fileURLWithPath: urlString, relativeTo: nil)
-                let xcode = Xcode(version: version, url: url, filename: String(url.path.suffix(fromLast: "/")))
-                return Promise.value((xcode, url))
-            }
-            else {
+                        return self.downloadXcode(version: latestNonPrereleaseXcode.version)
+                    }
+            case .latestPrerelease:
+                Current.logging.log("Updating...")
+                
+                return update()
+                    .then { availableXcodes -> Promise<(Xcode, URL)> in
+                        guard let latestPrereleaseXcode = availableXcodes.filter(\.isPrerelease).sorted(\.version).last else {
+                            throw Error.noNonPrereleaseVersionAvailable
+                        }
+                        Current.logging.log("Latest prerelease version available is \(latestPrereleaseXcode.version.xcodeDescription)")
+                        
+                        if let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: latestPrereleaseXcode.version) }) {
+                            throw Error.versionAlreadyInstalled(installedXcode)
+                        }
+                        
+                        return self.downloadXcode(version: latestPrereleaseXcode.version)
+                    }
+            case .url(let versionString, let path):
+                guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
+                    throw Error.invalidVersion(versionString)
+                }
+                let xcode = Xcode(version: version, url: path.url, filename: String(path.string.suffix(fromLast: "/")))
+                return Promise.value((xcode, path.url))
+            case .version(let versionString):
+                guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
+                    throw Error.invalidVersion(versionString)
+                }
+                if let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: version) }) {
+                    throw Error.versionAlreadyInstalled(installedXcode)
+                }
                 return self.downloadXcode(version: version)
             }
         }
@@ -383,19 +428,23 @@ public final class XcodeInstaller {
         }
     }
 
-    public func updateAndPrint() -> Promise<Void> {
+    func update() -> Promise<[Xcode]> {
         return firstly { () -> Promise<Void> in
             loginIfNeeded()
         }
         .then { () -> Promise<[Xcode]> in
             self.xcodeList.update()
         }
-        .then { xcodes -> Promise<Void> in
-            self.printAvailableXcodes(xcodes, installed: Current.files.installedXcodes())
-        }
-        .done {
-            Current.shell.exit(0)
-        }
+    }
+
+    public func updateAndPrint() -> Promise<Void> {
+        update()
+            .then { xcodes -> Promise<Void> in
+                self.printAvailableXcodes(xcodes, installed: Current.files.installedXcodes())
+            }
+            .done {
+                Current.shell.exit(0)
+            }
     }
 
     public func printAvailableXcodes(_ xcodes: [Xcode], installed installedXcodes: [InstalledXcode]) -> Promise<Void> {

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -195,7 +195,7 @@ final class XcodesKitTests: XCTestCase {
 
         let expectation = self.expectation(description: "Finished")
 
-        installer.install("0.0.0", nil)
+        installer.install(.version("0.0.0"))
             .ensure {
                 let url = URL(fileURLWithPath: "LogOutput-FullHappyPath.txt", 
                               relativeTo: URL(fileURLWithPath: #file).deletingLastPathComponent())

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -50,7 +50,7 @@ final class XcodesKitTests: XCTestCase {
             return (Progress(), Promise(error: PMKError.invalidCallingConvention))
         }
 
-        let xcode = Xcode(version: Version("0.0.0")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip")
+        let xcode = Xcode(version: Version("0.0.0")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil)
         installer.downloadOrUseExistingArchive(for: xcode, progressChanged: { _ in })
             .tap { result in
                 guard case .fulfilled(let value) = result else { XCTFail("downloadOrUseExistingArchive rejected."); return }
@@ -68,7 +68,7 @@ final class XcodesKitTests: XCTestCase {
             return (Progress(), Promise.value((destination, HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)))
         }
 
-        let xcode = Xcode(version: Version("0.0.0")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip")
+        let xcode = Xcode(version: Version("0.0.0")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil)
         installer.downloadOrUseExistingArchive(for: xcode, progressChanged: { _ in })
             .tap { result in
                 guard case .fulfilled(let value) = result else { XCTFail("downloadOrUseExistingArchive rejected."); return }
@@ -81,7 +81,7 @@ final class XcodesKitTests: XCTestCase {
     func test_InstallArchivedXcode_SecurityAssessmentFails_Throws() {
         Current.shell.spctlAssess = { _ in return Promise(error: Process.PMKError.execution(process: Process(), standardOutput: nil, standardError: nil)) }
 
-        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock")
+        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock", releaseDate: nil)
         let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-0.0.0.app")!)!
         installer.installArchivedXcode(xcode, at: URL(fileURLWithPath: "/Xcode-0.0.0.xip"))
             .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.failedSecurityAssessment(xcode: installedXcode, output: "")) }
@@ -90,7 +90,7 @@ final class XcodesKitTests: XCTestCase {
     func test_InstallArchivedXcode_VerifySigningCertificateFails_Throws() {
         Current.shell.codesignVerify = { _ in return Promise(error: Process.PMKError.execution(process: Process(), standardOutput: nil, standardError: nil)) }
 
-        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock")
+        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock", releaseDate: nil)
         installer.installArchivedXcode(xcode, at: URL(fileURLWithPath: "/Xcode-0.0.0.xip"))
             .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.codesignVerifyFailed(output: "")) }
     }
@@ -98,7 +98,7 @@ final class XcodesKitTests: XCTestCase {
     func test_InstallArchivedXcode_VerifySigningCertificateDoesntMatch_Throws() {
         Current.shell.codesignVerify = { _ in return Promise.value((0, "", "")) }
 
-        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock")
+        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock", releaseDate: nil)
         installer.installArchivedXcode(xcode, at: URL(fileURLWithPath: "/Xcode-0.0.0.xip"))
             .catch { error in XCTAssertEqual(error as! XcodeInstaller.Error, XcodeInstaller.Error.unexpectedCodeSigningIdentity(identifier: "", certificateAuthority: [])) }
     }
@@ -110,7 +110,7 @@ final class XcodesKitTests: XCTestCase {
             return URL(fileURLWithPath: "\(NSHomeDirectory())/.Trash/\(itemURL.lastPathComponent)")
         }
 
-        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock")
+        let xcode = Xcode(version: Version("0.0.0")!, url: URL(fileURLWithPath: "/"), filename: "mock", releaseDate: nil)
         let xipURL = URL(fileURLWithPath: "/Xcode-0.0.0.xip")
         installer.installArchivedXcode(xcode, at: xipURL)
             .ensure { XCTAssertEqual(trashedItemAtURL, xipURL) }
@@ -135,8 +135,10 @@ final class XcodesKitTests: XCTestCase {
         // It's an available release version
         Current.network.dataTask = { url in
             if url.pmkRequest.url! == URLRequest.downloads.url! {
-                let downloads = Downloads(downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip")])])
-                let downloadsData = try! JSONEncoder().encode(downloads)
+                let downloads = Downloads(downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip")], dateModified: Date())])
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .formatted(.downloadsDateModified)
+                let downloadsData = try! encoder.encode(downloads)
                 return Promise.value((data: downloadsData, response: HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
             }
 


### PR DESCRIPTION
This should be really handy during beta season because you can keep using the same command to get the latest version. 

The separate universal Xcode builds, which versions parse into Version structs a little strangely, means the implementation is a little more involved. The Version struct for `12.0 For Macos Universal Apps Beta 2` sorts last, which is not what we want when `12.0 Beta 4` was released later. In order to mitigate this xcodes now parses the release date or modified date for available Xcode versions, and sorts prerelease versions according to their dates instead of their Versions. This seems to work well, and so the following output for these commands is:

```
❯ swift run xcodes install --latest
Updating...
Latest non-prerelease version available is 11.6
11.6 is already installed at /Applications/Xcode-11.6.0.app

❯ swift run xcodes install --latest-prerelease
Updating...
Latest prerelease version available is 12.0 Beta 4 (12A8179i)
(1/6) Downloading Xcode 12.0.0-beta.4+12A8179i: 5%
```

Note that xcodes will also automatically update the list of available versions when using these flags.

## Testing

```sh
# This branch is on a fork, so check it out first:
git checkout -b interstateone-install-latest master
git pull https://github.com/interstateone/xcodes.git install-latest

# Then try running the install command with the new options
swift run xcodes install --latest
swift run xcodes install --latest-prerelease

# Make sure that it attempts to install the expected version (as of 2020/08/25 that's 11.6 or 12.0 beta 6)
```

Closes #36 