### PR TITLE
Improve error messages for underlying NSErrors and Swift errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,15 +29,6 @@
         }
       },
       {
-        "package": "LegibleError",
-        "repositoryURL": "https://github.com/mxcl/LegibleError.git",
-        "state": {
-          "branch": null,
-          "revision": "c615c01e461e8a3495ba4ea75f5d671c76820105",
-          "version": "1.0.1"
-        }
-      },
-      {
         "package": "Path.swift",
         "repositoryURL": "https://github.com/mxcl/Path.swift.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
         .package(url: "https://github.com/mxcl/PromiseKit.git", .upToNextMinor(from: "6.8.3")),
         .package(name: "PMKFoundation", url: "https://github.com/PromiseKit/Foundation.git", .upToNextMinor(from: "3.3.1")),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", .upToNextMinor(from: "2.0.0")),
-        .package(url: "https://github.com/mxcl/LegibleError.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.2.0"))
     ],
     targets: [
@@ -33,7 +32,7 @@ let package = Package(
         .target(
             name: "XcodesKit",
             dependencies: [
-                "AppleAPI", .product(name: "Path", package: "Path.swift"), "Version", "PromiseKit", "PMKFoundation", "SwiftSoup", "LegibleError", "KeychainAccess"
+                "AppleAPI", .product(name: "Path", package: "Path.swift"), "Version", "PromiseKit", "PMKFoundation", "SwiftSoup", "KeychainAccess"
             ]),
         .testTarget(
             name: "XcodesKitTests",

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -3,7 +3,6 @@ import PromiseKit
 import Path
 import AppleAPI
 import Version
-import LegibleError
 
 /// Downloads and installs Xcodes
 public final class XcodeInstaller {
@@ -204,7 +203,7 @@ public final class XcodeInstaller {
                 self.login(username, password: password)
             }
             .recover { error -> Promise<Void> in
-                Current.logging.log(error.legibleLocalizedDescription)
+                Current.logging.log(error.localizedDescription)
 
                 if case Client.Error.invalidUsernameOrPassword = error {
                     Current.logging.log("Try entering your password again")

--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -54,7 +54,7 @@ public func selectXcodeInteractively(currentPath: String, shouldRetry: Bool) -> 
             }
             .recover { error throws -> Promise<ProcessOutput> in
                 guard case XcodeSelectError.invalidIndex = error else { throw error }
-                Current.logging.log("\(error.legibleLocalizedDescription)\n")
+                Current.logging.log("\(error.localizedDescription)\n")
                 return selectWithRetry(currentPath: currentPath)
             }
         }

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -3,7 +3,6 @@ import Guaka
 import Version
 import PromiseKit
 import XcodesKit
-import LegibleError
 import Path
 
 var configuration = Configuration()
@@ -27,7 +26,7 @@ let installed = Command(usage: "installed",
             exit(0)
         }
         .catch { error in
-            print(error.legibleLocalizedDescription)
+            print(error.localizedDescription)
             exit(1)
         }
 
@@ -48,7 +47,7 @@ let select = Command(usage: "select <version or path>",
                               """) { flags, args in
     selectXcode(shouldPrint: flags.getBool(name: "print-path") ?? false, pathOrVersion: args.joined(separator: " "))
         .catch { error in
-            print(error.legibleLocalizedDescription)
+            print(error.localizedDescription)
             exit(1)
         }
 
@@ -70,7 +69,7 @@ let list = Command(usage: "list",
         exit(0)
     }
     .catch { error in
-        print(error.legibleLocalizedDescription)
+        print(error.localizedDescription)
         exit(1)
     }
 
@@ -84,7 +83,7 @@ let update = Command(usage: "update",
         installer.updateAndPrint()
     }
     .catch { error in
-        print(error.legibleLocalizedDescription)
+        print(error.localizedDescription)
         exit(1)
     }
 
@@ -112,7 +111,7 @@ let install = Command(usage: "install <version>",
                     \([standardOutput, standardError].compactMap { $0 }.joined(separator: "\n"))
                     """)
             default:
-                Current.logging.log(error.legibleLocalizedDescription)
+                Current.logging.log(error.localizedDescription)
             }
 
             exit(1)
@@ -128,7 +127,7 @@ let uninstall = Command(usage: "uninstall <version>",
         let versionString = args.joined(separator: " ")
     installer.uninstallXcode(versionString)
         .catch { error in
-            print(error.legibleLocalizedDescription)
+            print(error.localizedDescription)
             exit(1)
         }
 


### PR DESCRIPTION
LegibleError provides less valuable strings for NSErrors because [it intentionally doesn't return their localized descriptions](https://github.com/mxcl/LegibleError/blob/master/Sources/LegibleError.swift#L44) when they start with "The operation couldn’t be completed." This results in error messages like “ The operation couldn’t be completed. (NSPOSIXErrorDomain.28)” instead of “ The operation couldn’t be completed. No space left on device”. I think users would find the latter more valuable.

For NSErrors, I'm not sure if we should be doing something different in order to get better behaviour when using LegibleError. Setting NSLocalizedFailureErrorKey everywhere might be an option because that replaces "The operation couldn't be completed" at the start of the error’s localized description.

For Swift errors, LegibleDescription can provide much better errors, for example with DecodingError.

This PR began as a quick fix for #79 but I’m going to leave it as a draft because I’m not confident that the current change is better in all cases (see also #52 and #96), and it’s an opportunity to come up with more wholistic error modelling.

It may help to better define what we want to show to the user. This is a developer tool that can fail in the middle of a long-running process. We want user-friendly error messages so that they can attempt to recover on their own. I think we can err on the side of showing more technical information, like that something failed because of a JSON decoding error, because users will be familiar with this process. This should be _in addition_ to user-friendly messages, though, not in place of them. For example, we should display a failure reason and an OSStatus code instead of only the code. It can also be valuable for bug reporting purposes to print the description (which is more like a debug description, as opposed to localized description) of the error, and this should also be in addition to the localized description.