### PR TITLE
Add support for downloading with aria2 if it's already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ macOS User Password:
 Xcode 11.2.0 has been installed to /Applications/Xcode-11.2.0.app
 ```
 
+If you have [aria2](https://aria2.github.io) installed (it's available in Homebrew, `brew install aria2`), then xcodes will default to use it for downloads. It uses up to 16 connections to download Xcode 3-5x faster than URLSession.
+
 ### Commands
 
 - `install <version>`: Download and install a specific version of Xcode

--- a/Sources/XcodesKit/Aria2CError.swift
+++ b/Sources/XcodesKit/Aria2CError.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// A LocalizedError that represents a non-zero exit code from running aria2c.
+struct Aria2CError: LocalizedError {
+    var code: Code
+    
+    init?(exitStatus: Int32) {
+        guard let code = Code(rawValue: exitStatus) else { return nil }
+        self.code = code
+    }
+    
+    var errorDescription: String? {
+        "aria2c error: \(code.description)"
+    }
+    
+    // https://github.com/aria2/aria2/blob/master/src/error_code.h
+    enum Code: Int32, CustomStringConvertible {
+        case undefined = -1
+        // Ignoring, not an error
+        // case finished = 0
+        case unknownError = 1
+        case timeOut
+        case resourceNotFound
+        case maxFileNotFound
+        case tooSlowDownloadSpeed
+        case networkProblem
+        case inProgress
+        case cannotResume
+        case notEnoughDiskSpace
+        case pieceLengthChanged
+        case duplicateDownload
+        case duplicateInfoHash
+        case fileAlreadyExists
+        case fileRenamingFailed
+        case fileOpenError
+        case fileCreateError
+        case fileIoError
+        case dirCreateError
+        case nameResolveError
+        case metalinkParseError
+        case ftpProtocolError
+        case httpProtocolError
+        case httpTooManyRedirects
+        case httpAuthFailed
+        case bencodeParseError
+        case bittorrentParseError
+        case magnetParseError
+        case optionError
+        case httpServiceUnavailable
+        case jsonParseError
+        case removed
+        case checksumError
+        
+        var description: String {
+            switch self {
+            case .undefined:
+                return "Undefined"
+            case .unknownError:
+                return "Unknown error"
+            case .timeOut:
+                return "Timed out"
+            case .resourceNotFound:
+                return "Resource not found"
+            case .maxFileNotFound:
+                return "Maximum number of file not found errors reached"
+            case .tooSlowDownloadSpeed:
+                return "Download speed too slow"
+            case .networkProblem:
+                return "Network problem"
+            case .inProgress:
+                return "Unfinished downloads in progress"
+            case .cannotResume:
+                return "Remote server did not support resume when resume was required to complete download"
+            case .notEnoughDiskSpace:
+                return "Not enough disk space available"
+            case .pieceLengthChanged:
+                return "Piece length was different from one in .aria2 control file"
+            case .duplicateDownload:
+                return "Duplicate download"
+            case .duplicateInfoHash:
+                return "Duplicate info hash torrent"
+            case .fileAlreadyExists:
+                return "File already exists"
+            case .fileRenamingFailed:
+                return "Renaming file failed"
+            case .fileOpenError:
+                return "Could not open existing file"
+            case .fileCreateError:
+                return "Could not create new file or truncate existing file"
+            case .fileIoError:
+                return "File I/O error"
+            case .dirCreateError:
+                return "Could not create directory"
+            case .nameResolveError:
+                return "Name resolution failed"
+            case .metalinkParseError:
+                return "Could not parse Metalink document"
+            case .ftpProtocolError:
+                return "FTP command failed"
+            case .httpProtocolError:
+                return "HTTP response header was bad or unexpected"
+            case .httpTooManyRedirects:
+                return "Too many redirects occurred"
+            case .httpAuthFailed:
+                return "HTTP authorization failed"
+            case .bencodeParseError:
+                return "Could not parse bencoded file (usually \".torrent\" file)"
+            case .bittorrentParseError:
+                return "\".torrent\" file was corrupted or missing information"
+            case .magnetParseError:
+                return "Magnet URI was bad"
+            case .optionError:
+                return "Bad/unrecognized option was given or unexpected option argument was given"
+            case .httpServiceUnavailable:
+                return "HTTP service unavailable"
+            case .jsonParseError:
+                return "Could not parse JSON-RPC request"
+            case .removed:
+                return "Reserved. Not used."
+            case .checksumError:
+                return "Checksum validation failed"
+            }
+        }
+    }
+}

--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -53,6 +53,81 @@ public struct Shell {
     public func xcodeSelectSwitch(password: String?, path: String) -> Promise<ProcessOutput> {
         xcodeSelectSwitch(password, path)
     }
+    
+    public var downloadWithAria2: (Path, URL, Path, [HTTPCookie]) -> (Progress, Promise<Void>) = { aria2Path, url, destination, cookies in
+        let process = Process()
+        process.executableURL = aria2Path.url
+        process.arguments = [
+            "--header=Cookie: \(cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; "))",     
+            "--max-connection-per-server=16",
+            "--split=16",
+            "--summary-interval=1",
+            "--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)",
+            "--dir=\(destination.parent.string)",
+            "--out=\(destination.basename())",
+            url.absoluteString,
+        ]
+        let stdOutPipe = Pipe()
+        process.standardOutput = stdOutPipe
+        let stdErrPipe = Pipe()
+        process.standardError = stdErrPipe
+        
+        var progress = Progress(totalUnitCount: 100)
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: .NSFileHandleDataAvailable, 
+            object: nil, 
+            queue: OperationQueue.main
+        ) { note in
+            guard
+                // This should always be the case for Notification.Name.NSFileHandleDataAvailable
+                let handle = note.object as? FileHandle,
+                handle === stdOutPipe.fileHandleForReading || handle === stdErrPipe.fileHandleForReading
+            else { return }
+
+            defer { handle.waitForDataInBackgroundAndNotify() }
+
+            let string = String(decoding: handle.availableData, as: UTF8.self)
+            let regex = try! NSRegularExpression(pattern: #"((?<percent>\d+)%\))"#)
+            let range = NSRange(location: 0, length: string.utf16.count)
+
+            guard
+                let match = regex.firstMatch(in: string, options: [], range: range),
+                let matchRange = Range(match.range(withName: "percent"), in: string),
+                let percentCompleted = Int64(string[matchRange])
+            else { return }
+
+            progress.completedUnitCount = percentCompleted
+        }
+
+        stdOutPipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
+        stdErrPipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
+        
+        do {
+            try process.run()
+        } catch {
+            return (progress, Promise(error: error))
+        }
+
+        let promise = Promise<Void> { seal in
+            DispatchQueue.global(qos: .default).async {
+                process.waitUntilExit()
+                
+                NotificationCenter.default.removeObserver(observer, name: .NSFileHandleDataAvailable, object: nil)
+
+                guard process.terminationReason == .exit, process.terminationStatus == 0 else {
+                    if let aria2cError = Aria2CError(exitStatus: process.terminationStatus) {
+                        return seal.reject(aria2cError)
+                    } else {
+                        return seal.reject(Process.PMKError.execution(process: process, standardOutput: "", standardError: ""))
+                    }
+                }
+                seal.fulfill(())
+            }
+        }
+        
+        return (progress, promise)
+    }
 
     public var readLine: (String) -> String? = { prompt in
         print(prompt, terminator: "")

--- a/Sources/XcodesKit/Promise+.swift
+++ b/Sources/XcodesKit/Promise+.swift
@@ -1,0 +1,40 @@
+import Foundation
+import PromiseKit
+
+/// Attempt and retry a task that fails with resume data up to `maximumRetryCount` times
+func attemptResumableTask<T>(
+    maximumRetryCount: Int = 3,
+    delayBeforeRetry: DispatchTimeInterval = .seconds(2),
+    _ body: @escaping (Data?) -> Promise<T>
+) -> Promise<T> {
+    var attempts = 0
+    func attempt(with resumeData: Data? = nil) -> Promise<T> {
+        attempts += 1
+        return body(resumeData).recover { error -> Promise<T> in
+            guard
+                attempts < maximumRetryCount,
+                let resumeData = (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+            else { throw error }
+
+            return after(delayBeforeRetry).then(on: nil) { attempt(with: resumeData) }
+        }
+    }
+    return attempt()
+}
+
+/// Attempt and retry a task up to `maximumRetryCount` times
+func attemptRetryableTask<T>(
+    maximumRetryCount: Int = 3,
+    delayBeforeRetry: DispatchTimeInterval = .seconds(2),
+    _ body: @escaping () -> Promise<T>
+) -> Promise<T> {
+    var attempts = 0
+    func attempt() -> Promise<T> {
+        attempts += 1
+        return body().recover { error -> Promise<T> in
+            guard attempts < maximumRetryCount else { throw error }
+            return after(delayBeforeRetry).then(on: nil) { attempt() }
+        }
+    }
+    return attempt()
+}

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -61,13 +61,13 @@ extension XcodeList {
                 .downloads
                 .filter { $0.name.range(of: "^Xcode [0-9]", options: .regularExpression) != nil }
                 .compactMap { download -> Xcode? in
-                    let urlPrefix = "https://developer.apple.com/devcenter/download.action?path="
+                    let urlPrefix = URL(string: "https://download.developer.apple.com/")!
                     guard 
                         let xcodeFile = download.files.first(where: { $0.remotePath.hasSuffix("dmg") || $0.remotePath.hasSuffix("xip") }),
-                        let url = URL(string: urlPrefix + xcodeFile.remotePath),
                         let version = Version(xcodeVersion: download.name)
                     else { return nil }
 
+                    let url = urlPrefix.appendingPathComponent(xcodeFile.remotePath)
                     return Xcode(version: version, url: url, filename: String(xcodeFile.remotePath.suffix(fromLast: "/")), releaseDate: download.dateModified)
                 }
             return xcodes

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -51,7 +51,7 @@ final class XcodesKitTests: XCTestCase {
         }
 
         let xcode = Xcode(version: Version("0.0.0")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil)
-        installer.downloadOrUseExistingArchive(for: xcode, progressChanged: { _ in })
+        installer.downloadOrUseExistingArchive(for: xcode, downloader: .urlSession, progressChanged: { _ in })
             .tap { result in
                 guard case .fulfilled(let value) = result else { XCTFail("downloadOrUseExistingArchive rejected."); return }
                 XCTAssertEqual(value, Path.applicationSupport.join("com.robotsandpencils.xcodes").join("Xcode-0.0.0.xip").url)
@@ -69,7 +69,7 @@ final class XcodesKitTests: XCTestCase {
         }
 
         let xcode = Xcode(version: Version("0.0.0")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil)
-        installer.downloadOrUseExistingArchive(for: xcode, progressChanged: { _ in })
+        installer.downloadOrUseExistingArchive(for: xcode, downloader: .urlSession, progressChanged: { _ in })
             .tap { result in
                 guard case .fulfilled(let value) = result else { XCTFail("downloadOrUseExistingArchive rejected."); return }
                 XCTAssertEqual(value, Path.applicationSupport.join("com.robotsandpencils.xcodes").join("Xcode-0.0.0.xip").url)
@@ -197,7 +197,7 @@ final class XcodesKitTests: XCTestCase {
 
         let expectation = self.expectation(description: "Finished")
 
-        installer.install(.version("0.0.0"))
+        installer.install(.version("0.0.0"), downloader: .urlSession)
             .ensure {
                 let url = Bundle.module.url(forResource: "LogOutput-FullHappyPath", withExtension: "txt", subdirectory: "Fixtures")!
                 XCTAssertEqual(log, try! String(contentsOf: url))
@@ -312,7 +312,7 @@ final class XcodesKitTests: XCTestCase {
 
         let expectation = self.expectation(description: "Finished")
 
-        installer.install(.version("0.0.0"))
+        installer.install(.version("0.0.0"), downloader: .urlSession)
             .ensure {
                 let url = Bundle.module.url(forResource: "LogOutput-DamagedXIP", withExtension: "txt", subdirectory: "Fixtures")!
                 let expectedText = try! String(contentsOf: url).replacingOccurrences(of: "/Users/brandon", with: Path.home.string)


### PR DESCRIPTION
By default, xcodes will use a URLSession to download the specified version. If [aria2](https://aria2.github.io) (available in Homebrew with `brew install aria2`) is installed, either at /usr/local/bin/aria2c or at the path specified by the --aria2 flag, then it will be used instead. aria2 will use up to 16 connections to download Xcode 3-5x faster (based on a couple tests on my residential internet). If you have aria2 installed and would prefer to not use it, you can use the --no-aria2 flag.

aria2 downloads should retry up to 3 times if it fails in the middle, just like URLSession. Errors that cause aria2c to exit with a non-zero status code will show an appropriate error message.

In order to support both aria2 and URLSession, I had to change the download URLs. The previous URL prefix still works, but I was having issues with it when using aria2 for downloads. This new URL prefix matches whats shown in a browser at developer.apple.com/download/more, and works with both URLSession and aria2.

Closes #93 

## Testing

Download a bunch of xcodes while you're on this branch 😄 

First, clone this repo if necessary and check out the PR branch:

```
git clone https://github.com/RobotsAndPencils/xcodes.git
cd xcodes
git checkout -b interstateone-aria2 master
git pull https://github.com/interstateone/xcodes.git aria2
```

You can test this new behaviour with your own account using a command like:

```
swift run xcodes install 12.1 gm seed # or some other version that you don't have already
```

You should try installing both with and without aria2, so:
- without aria2c
- with aria2c
- with aria2c and --no-aria2 flag to use URLSession

You can see if aria2c is being used during install by opening Activity Monitor and filtering for `aria2c` in the top right.