### PR TITLE
Allow selecting with short version

### DIFF
--- a/Sources/XcodesKit/Version+.swift
+++ b/Sources/XcodesKit/Version+.swift
@@ -8,6 +8,12 @@ public extension Version {
                prereleaseIdentifiers == other.prereleaseIdentifiers
     }
 
+    func isEqualWithoutAllIdentifiers(to other: Version) -> Bool {
+        return major == other.major &&
+               minor == other.minor &&
+               patch == other.patch
+    }
+
     /// If release versions, don't compare build metadata because that's not provided in the /downloads/more list
     /// if beta versions, compare build metadata because it's available in versions.plist
     func isEquivalentForDeterminingIfInstalled(toInstalled installed: Version) -> Bool {

--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -21,8 +21,21 @@ public func selectXcode(shouldPrint: Bool, pathOrVersion: String) -> Promise<Voi
             }
         }
 
+        // Look for the exact provided version first
         if let version = Version(xcodeVersion: pathOrVersion),
            let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: version) }) {
+            return selectXcodeAtPath(installedXcode.path.string)
+                .done { output in
+                    Current.logging.log("Selected \(output.out)")
+                    Current.shell.exit(0)
+                }
+        }
+        // If a short version is provided, look again for a match, ignore all
+        // identifiers this time. Ignore if there are more than one match.
+        else if let version = Version(xcodeVersion: pathOrVersion),
+            version.prereleaseIdentifiers.isEmpty && version.buildMetadataIdentifiers.isEmpty,
+            Current.files.installedXcodes().filter({ $0.version.isEqualWithoutAllIdentifiers(to: version) }).count == 1 {
+            let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutAllIdentifiers(to: version) })!
             return selectXcodeAtPath(installedXcode.path.string)
                 .done { output in
                     Current.logging.log("Selected \(output.out)")

--- a/Tests/XcodesKitTests/Version+XcodeTests.swift
+++ b/Tests/XcodesKitTests/Version+XcodeTests.swift
@@ -33,4 +33,13 @@ class VersionXcodeTests: XCTestCase {
         XCTAssertFalse(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1-beta+abcdef")!))
         XCTAssertTrue(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1-beta+QWERTY")!))
     }
+
+    func test_XcodeVersionEquivalence() {
+        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12")!))
+        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0")!))
+        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0.0")!))
+        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12")!))
+        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0")!))
+        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0.0")!))
+    }
 }


### PR DESCRIPTION
If a short version is provided, xcodes will select a matched one if
there is only a single match found in the machine. This allows, for
example, if user has Xcode 12.0 GM Seed installed and has no other 12.0
installed, `xcodes select 12.0` will select it.

Fixes https://github.com/RobotsAndPencils/xcodes/issues/114.
