### PR TITLE
Allow somewhat fuzzy version matching for install and uninstall commands

### DIFF
--- a/Sources/XcodesKit/Models+FirstWithVersion.swift
+++ b/Sources/XcodesKit/Models+FirstWithVersion.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Version
+
+/// Returns the first XcodeType that unambiguously has the same version as `version`.
+///
+/// If there's an exact match that takes prerelease identifiers into account, that's returned.
+/// Otherwise, if a version without prerelease or build metadata identifiers is provided, and there's a single match based on only the major, minor and patch numbers, that's returned.
+/// If there are multiple matches, or no matches, nil is returned.
+public func findXcode<XcodeType>(version: Version, in xcodes: [XcodeType], versionKeyPath: KeyPath<XcodeType, Version>) -> XcodeType? {
+    // Look for the exact provided version first
+    if let installedXcode = xcodes.first(where: { $0[keyPath: versionKeyPath].isEqualWithoutBuildMetadataIdentifiers(to: version) }) {
+        return installedXcode
+    }
+    // If a short version is provided, look again for a match, ignore all
+    // identifiers this time. Ignore if there are more than one match.
+    else if version.prereleaseIdentifiers.isEmpty && version.buildMetadataIdentifiers.isEmpty,
+        xcodes.filter({ $0[keyPath: versionKeyPath].isEqualWithoutAllIdentifiers(to: version) }).count == 1 {
+        let installedXcode = xcodes.first(where: { $0[keyPath: versionKeyPath].isEqualWithoutAllIdentifiers(to: version) })!
+        return installedXcode
+    } else {
+        return nil
+    }
+}
+
+public extension Array where Element == Xcode {
+    /// Returns the first Xcode that unambiguously has the same version as `version`.
+    ///
+    /// If there's an exact match that takes prerelease identifiers into account, that's returned.
+    /// Otherwise, if a version without prerelease or build metadata identifiers is provided, and there's a single match based on only the major, minor and patch numbers, that's returned.
+    /// If there are multiple matches, or no matches, nil is returned.
+    func first(withVersion version: Version) -> Xcode? {
+        findXcode(version: version, in: self, versionKeyPath: \.version)
+    }
+}
+
+public extension Array where Element == InstalledXcode {
+    /// Returns the first InstalledXcode that unambiguously has the same version as `version`.
+    ///
+    /// If there's an exact match that takes prerelease identifiers into account, that's returned.
+    /// Otherwise, if a version without prerelease or build metadata identifiers is provided, and there's a single match based on only the major, minor and patch numbers, that's returned.
+    /// If there are multiple matches, or no matches, nil is returned.
+    func first(withVersion version: Version) -> InstalledXcode? {
+        findXcode(version: version, in: self, versionKeyPath: \.version)
+    } 
+}

--- a/Sources/XcodesKit/Models.swift
+++ b/Sources/XcodesKit/Models.swift
@@ -6,6 +6,11 @@ public struct InstalledXcode: Equatable {
     public let path: Path
     /// Composed of the bundle short version from Info.plist and the product build version from version.plist
     public let version: Version
+    
+    init(path: Path, version: Version) {
+        self.path = path
+        self.version = version
+    }
 
     public init?(path: Path) {
         self.path = path
@@ -39,7 +44,7 @@ public struct InstalledXcode: Equatable {
     }
 }
 
-public struct Xcode: Codable {
+public struct Xcode: Codable, Equatable {
     public let version: Version
     public let url: URL
     public let filename: String

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -259,7 +259,7 @@ public final class XcodeInstaller {
             }
         }
         .then { version -> Promise<(Xcode, URL)> in
-            guard let xcode = self.xcodeList.availableXcodes.first(where: { version.isEqualWithoutBuildMetadataIdentifiers(to: $0.version) }) else {
+            guard let xcode = self.xcodeList.availableXcodes.first(withVersion: version) else {
                 throw Error.unavailableVersion(version)
             }
 
@@ -479,7 +479,7 @@ public final class XcodeInstaller {
                 throw Error.invalidVersion(versionString)
             }
 
-            guard let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: version) }) else {
+            guard let installedXcode = Current.files.installedXcodes().first(withVersion: version) else {
                 throw Error.versionNotInstalled(version)
             }
 

--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -21,21 +21,8 @@ public func selectXcode(shouldPrint: Bool, pathOrVersion: String) -> Promise<Voi
             }
         }
 
-        // Look for the exact provided version first
         if let version = Version(xcodeVersion: pathOrVersion),
-           let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: version) }) {
-            return selectXcodeAtPath(installedXcode.path.string)
-                .done { output in
-                    Current.logging.log("Selected \(output.out)")
-                    Current.shell.exit(0)
-                }
-        }
-        // If a short version is provided, look again for a match, ignore all
-        // identifiers this time. Ignore if there are more than one match.
-        else if let version = Version(xcodeVersion: pathOrVersion),
-            version.prereleaseIdentifiers.isEmpty && version.buildMetadataIdentifiers.isEmpty,
-            Current.files.installedXcodes().filter({ $0.version.isEqualWithoutAllIdentifiers(to: version) }).count == 1 {
-            let installedXcode = Current.files.installedXcodes().first(where: { $0.version.isEqualWithoutAllIdentifiers(to: version) })!
+           let installedXcode = Current.files.installedXcodes().first(withVersion: version) {
             return selectXcodeAtPath(installedXcode.path.string)
                 .done { output in
                     Current.logging.log("Selected \(output.out)")

--- a/Tests/XcodesKitTests/Models+FirstWithVersionTests.swift
+++ b/Tests/XcodesKitTests/Models+FirstWithVersionTests.swift
@@ -1,0 +1,104 @@
+import Path
+import XCTest
+import Version
+@testable import XcodesKit
+
+final class ModelsFirstWithVersionTests: XCTestCase {
+    let xcodes = [
+        Xcode(version: Version(xcodeVersion: "1.2.3")!,        url: URL(fileURLWithPath: "https://developer.apple.com/Xcode1.2.3.app"),      filename: "Xcode1.2.3.app",      releaseDate: nil),
+        Xcode(version: Version(xcodeVersion: "1.2.3 Beta 1")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode1.2.3Beta1.app"), filename: "Xcode1.2.3Beta1.app", releaseDate: nil),
+        Xcode(version: Version(xcodeVersion: "1.2.3 Beta 2")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode1.2.3Beta2.app"), filename: "Xcode1.2.3Beta2.app", releaseDate: nil),
+        
+        Xcode(version: Version(xcodeVersion: "4.5.6 Beta 1")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode4.5.6Beta1.app"), filename: "Xcode4.5.6Beta1app",  releaseDate: nil),
+        Xcode(version: Version(xcodeVersion: "4.5.6 Beta 2")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode4.5.6Beta2.app"), filename: "Xcode4.5.6Beta2.app", releaseDate: nil),
+        
+        Xcode(version: Version(xcodeVersion: "7.8.9")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9.app"), filename: "Xcode7.8.9.app", releaseDate: nil),
+        
+        Xcode(version: Version(xcodeVersion: "10.11.12 Release Candidate")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode10.11.12ReleaseCandidate.app"), filename: "Xcode10.11.12ReleaseCandidate.app", releaseDate: nil),
+    ]
+    
+    let installedXcodes = [
+        InstalledXcode(path: Path("/Applications/Xcode-1.2.3.app")!,        version: Version(xcodeVersion: "1.2.3")!),
+        InstalledXcode(path: Path("/Applications/Xcode-1.2.3-beta.1.app")!, version: Version(xcodeVersion: "1.2.3 Beta 1")!),
+        InstalledXcode(path: Path("/Applications/Xcode-1.2.3-beta.2.app")!, version: Version(xcodeVersion: "1.2.3 Beta 2")!),
+        
+        InstalledXcode(path: Path("/Applications/Xcode-4.5.6-beta.1.app")!, version: Version(xcodeVersion: "4.5.6 Beta 1")!),
+        InstalledXcode(path: Path("/Applications/Xcode-4.5.6-beta.2.app")!, version: Version(xcodeVersion: "4.5.6 Beta 2")!),
+        
+        InstalledXcode(path: Path("/Applications/Xcode-7.8.9.app")!, version: Version(xcodeVersion: "7.8.9")!),
+        
+        InstalledXcode(path: Path("/Applications/Xcode-10.11.12-release.candidate.app")!, version: Version(xcodeVersion: "10.11.12 Release Candidate")!),
+    ]
+    
+    func test_xcodes_exactMatch() {
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "1.2.3")!),
+            Xcode(version: Version(xcodeVersion: "1.2.3")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode1.2.3.app"), filename: "Xcode1.2.3.app", releaseDate: nil)
+        )
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "1.2.3 Beta 2")!),
+            Xcode(version: Version(xcodeVersion: "1.2.3 Beta 2")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode1.2.3Beta2.app"), filename: "Xcode1.2.3Beta2.app", releaseDate: nil)
+        )
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "7.8.9")!),
+            Xcode(version: Version(xcodeVersion: "7.8.9")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9.app"), filename: "Xcode7.8.9.app", releaseDate: nil)
+        )
+    }
+    
+    func test_xcodes_fuzzyMatch() {
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "10.11.12")!),
+            Xcode(version: Version(xcodeVersion: "10.11.12 Release Candidate")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode10.11.12ReleaseCandidate.app"), filename: "Xcode10.11.12ReleaseCandidate.app", releaseDate: nil)
+        )
+    }
+    
+    func test_xcodes_noMatch() {
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "3.4.5")!),
+            nil
+        )
+    }
+    
+    func test_xcodes_multipleMatches() {
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "4.5.6")!),
+            nil
+        )
+    }
+    
+    func test_installedXcodes_exactMatch() {
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "1.2.3")!),
+            InstalledXcode(path: Path("/Applications/Xcode-1.2.3.app")!, version: Version(xcodeVersion: "1.2.3")!)
+        )
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "1.2.3 Beta 2")!),
+            InstalledXcode(path: Path("/Applications/Xcode-1.2.3-beta.2.app")!, version: Version(xcodeVersion: "1.2.3 Beta 2")!)
+        )
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "7.8.9")!),
+            InstalledXcode(path: Path("/Applications/Xcode-7.8.9.app")!, version: Version(xcodeVersion: "7.8.9")!)
+        )
+    }
+    
+    func test_installedXcodes_fuzzyMatch() {
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "10.11.12")!),
+            InstalledXcode(path: Path("/Applications/Xcode-10.11.12-release.candidate.app")!, version: Version(xcodeVersion: "10.11.12 Release Candidate")!)
+        )
+    }
+    
+    func test_installedXcodes_noMatch() {
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "3.4.5")!),
+            nil
+        )
+    }
+    
+    func test_installedXcodes_multipleMatches() {
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "4.5.6")!),
+            nil
+        )
+    }
+}


### PR DESCRIPTION
This PR extracts the behaviour added in #115, which allows users to omit prerelease identifiers (like "beta 2") in command arguments when it's unambiguous, and uses it in the install and uninstall commands. If the version is ambiguous then it should fail.

## Testing

First, clone this repo if necessary and check out the PR branch:

```
git clone https://github.com/RobotsAndPencils/xcodes.git
cd xcodes
git checkout -b interstateone-116-fuzzy-install-uninstall master
git pull https://github.com/interstateone/xcodes.git 116-fuzzy-install-uninstall
```

Right now there's a 12.3 beta available, and with this change you should be able to install it without specifying the beta identifier:

```
swift run xcodes update
swift run xcodes install 12.3
```

The tests that were added provide examples of how this should work in other situations, and you can try out the install and uninstall commands to verify. If there's an exact match even if there are multiple possible matches (like `12.2`, when `12.2`, `12.2 beta 1`, `12.2 beta 2`, `12.2 beta 3`, and `12.2 release candidate` are available) then it'll match `12.2`. Once the next 12.3 beta is released then `12.3` is no longer unambiguous and would fail to match.

Closes #116.