### PR TITLE
Search PATH for aria2c

### DIFF
--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -54,6 +54,19 @@ public struct Shell {
         xcodeSelectSwitch(password, path)
     }
     
+    /// Returns the path of an executable within the directories in the PATH environment variable.
+    public var findExecutable: (_ executableName: String) -> Path? = { executableName in
+        guard let path = ProcessInfo.processInfo.environment["PATH"] else { return nil }
+
+        for directory in path.components(separatedBy: ":") {
+            if let executable = Path(directory)?.join(executableName), executable.isExecutable {
+                return executable
+            }
+        }
+        
+        return nil
+    }
+    
     public var downloadWithAria2: (Path, URL, Path, [HTTPCookie]) -> (Progress, Promise<Void>) = { aria2Path, url, destination, cookies in
         let process = Process()
         process.executableURL = aria2Path.url

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -126,8 +126,9 @@ let install = Command(usage: "install <version>",
     }
     
     var downloader = XcodeInstaller.Downloader.urlSession
-    let aria2Path = flags.getString(name: "aria2").flatMap(Path.init) ?? Path.root.usr.local.bin/"aria2c"
-    if aria2Path.exists, flags.getBool(name: "no-aria2") != true {
+    if let aria2Path = flags.getString(name: "aria2").flatMap(Path.init) ?? Current.shell.findExecutable("aria2c"),
+       aria2Path.exists, 
+       flags.getBool(name: "no-aria2") != true {
         downloader = .aria2(aria2Path)
     } 
 


### PR DESCRIPTION
This changes where xcodes looks for the aria2c executable from the hard-coded `/usr/local/bin/aria2c`, which is where Homebrew will install it, to all of the directories in the user's PATH environment variable. The motivation for this is twofold:

- Homebrew will be changing it's "prefix" (where it installs things) as it adds support for Apple Silicon
- xcodes should support users who use other package managers like MacPorts, or who have manually installed aria2 to some other directory in their PATH

## Testing

First, clone this repo if necessary and check out the PR branch:

```
git clone https://github.com/RobotsAndPencils/xcodes.git
cd xcodes
git checkout -b interstateone-search-path-for-aria2c master
git pull https://github.com/interstateone/xcodes.git search-path-for-aria2c
```

If you already have aria2 installed via Homebrew, then xcodes should automatically use it like it did before this change. You can verify this by installing an Xcode with xcodes and then verifying that aria2c is running in Activity Monitor.

`swift run xcodes install 12.3`

If you have aria2 installed to another location in your PATH, then it should also use aria2c to download Xcode now. You can test this by moving it from /usr/local/bin to another location in your PATH. You can see what directories are in PATH with `echo ${PATH//:/\\n}`, which splits the directories on `:` and prints them on their own lines (https://stackoverflow.com/a/5257398).

Closes #118