### PR TITLE
renamed --url flag to --path for consistency

### DIFF
--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -163,7 +163,7 @@ public final class XcodeInstaller {
 
                 switch installationType {
                 case .path:
-                    // If the user provided the URL, don't try to recover and leave it up to them.
+                    // If the user provided the path, don't try to recover and leave it up to them.
                     throw error
                 default:
                     // If the XIP was just downloaded, remove it and try to recover.

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -129,7 +129,7 @@ public final class XcodeInstaller {
     
     public enum InstallationType {
         case version(String)
-        case url(String, Path)
+        case path(String, Path)
         case latest
         case latestPrerelease
     }
@@ -162,7 +162,7 @@ public final class XcodeInstaller {
                 guard attemptNumber < 1 else { throw error }
 
                 switch installationType {
-                case .url:
+                case .path:
                     // If the user provided the URL, don't try to recover and leave it up to them.
                     throw error
                 default:
@@ -220,7 +220,7 @@ public final class XcodeInstaller {
                         
                         return self.downloadXcode(version: latestPrereleaseXcode.version, downloader: downloader)
                     }
-            case .url(let versionString, let path):
+            case .path(let versionString, let path):
                 guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
                     throw Error.invalidVersion(versionString)
                 }

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -119,8 +119,8 @@ let install = Command(usage: "install <version>",
         installation = .latest
     } else if flags.getBool(name: "latest-prerelease") == true {
         installation = .latestPrerelease
-    } else if let url = flags.getString(name: "path"), let path = Path(url) {
-        installation = .url(versionString, path)
+    } else if let pathString = flags.getString(name: "path"), let path = Path(pathString) {
+        installation = .path(versionString, path)
     } else {
         installation = .version(versionString)
     }

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -92,7 +92,7 @@ let update = Command(usage: "update",
 }
 app.add(subCommand: update)
 
-let urlFlag = Flag(longName: "url", type: String.self, description: "Local path to Xcode .xip")
+let pathFlag = Flag(longName: "path", type: String.self, description: "Local path to Xcode .xip")
 let latestFlag = Flag(longName: "latest", value: false, description: "Update and then install the latest non-prerelease version available.")
 let latestPrereleaseFlag = Flag(longName: "latest-prerelease", value: false, description: "Update and then install the latest prerelease version available, including GM seeds and GMs.")
 let aria2 = Flag(longName: "aria2", type: String.self, description: "The path to an aria2 executable. Defaults to /usr/local/bin/aria2c.")
@@ -104,12 +104,12 @@ let install = Command(usage: "install <version>",
 
                       By default, xcodes will use a URLSession to download the specified version. If aria2 (https://aria2.github.io, available in Homebrew) is installed, either at /usr/local/bin/aria2c or at the path specified by the --aria2 flag, then it will be used instead. aria2 will use up to 16 connections to download Xcode 3-5x faster. If you have aria2 installed and would prefer to not use it, you can use the --no-aria2 flag.
                       """,
-                      flags: [urlFlag, latestFlag, latestPrereleaseFlag, aria2, noAria2],
+                      flags: [pathFlag, latestFlag, latestPrereleaseFlag, aria2, noAria2],
                       example: """
                                xcodes install 10.2.1
                                xcodes install 11 Beta 7
                                xcodes install 11.2 GM seed
-                               xcodes install 9.0 --url ~/Archive/Xcode_9.xip
+                               xcodes install 9.0 --path ~/Archive/Xcode_9.xip
                                xcodes install --latest-prerelease
                                """) { flags, args in
     let versionString = args.joined(separator: " ")
@@ -119,7 +119,7 @@ let install = Command(usage: "install <version>",
         installation = .latest
     } else if flags.getBool(name: "latest-prerelease") == true {
         installation = .latestPrerelease
-    } else if let url = flags.getString(name: "url"), let path = Path(url) {
+    } else if let url = flags.getString(name: "path"), let path = Path(url) {
         installation = .url(versionString, path)
     } else {
         installation = .version(versionString)


### PR DESCRIPTION
Small change that I've found helpful and more concise than using "--url" flag for command "install" is "--path" flag. "--url" implies that it's possible to specify a remote URL where the downloaded version would be put. But the actual implementation doesn't take this into account while relying on Path dependency (which makes total sense)