### PR TITLE
Use Xcode 12.2 and revert to swift test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,5 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - name: Run tests
       env: 
-        DEVELOPER_DIR: /Applications/Xcode_12.app
-      # Normally would use `swift test` but there's a bug related to SPM package resources, so using xcodebuild as a workaround
-      # https://forums.swift.org/t/swift-5-3-spm-resources-in-tests-uses-wrong-bundle-path/37051/10
-      run: xcodebuild test -scheme xcodes
+        DEVELOPER_DIR: /Applications/Xcode_12.2.app
+      run: swift test


### PR DESCRIPTION
The package bug this was working around has been fixed in Xcode 12.2, which is now available on GitHub's hosted runners. That CI is green here should be sufficient to prove it works as intended.