### PR TITLE
fix(XcodeInstaller): Infinite auth fail loop

### DIFF
--- a/Tests/XcodesKitTests/Fixtures/LogOutput-IncorrectSavedPassword.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-IncorrectSavedPassword.txt
@@ -1,0 +1,114 @@
+Apple ID: 
+Invalid username and password combination. Attempted to sign in with username test@example.com.
+Try entering your password again
+Apple ID Password (test@example.com): 
+
+[1A[K(1/6) Downloading Xcode 0.0.0: 1%
+[1A[K(1/6) Downloading Xcode 0.0.0: 2%
+[1A[K(1/6) Downloading Xcode 0.0.0: 3%
+[1A[K(1/6) Downloading Xcode 0.0.0: 4%
+[1A[K(1/6) Downloading Xcode 0.0.0: 5%
+[1A[K(1/6) Downloading Xcode 0.0.0: 6%
+[1A[K(1/6) Downloading Xcode 0.0.0: 7%
+[1A[K(1/6) Downloading Xcode 0.0.0: 8%
+[1A[K(1/6) Downloading Xcode 0.0.0: 9%
+[1A[K(1/6) Downloading Xcode 0.0.0: 10%
+[1A[K(1/6) Downloading Xcode 0.0.0: 11%
+[1A[K(1/6) Downloading Xcode 0.0.0: 12%
+[1A[K(1/6) Downloading Xcode 0.0.0: 13%
+[1A[K(1/6) Downloading Xcode 0.0.0: 14%
+[1A[K(1/6) Downloading Xcode 0.0.0: 15%
+[1A[K(1/6) Downloading Xcode 0.0.0: 16%
+[1A[K(1/6) Downloading Xcode 0.0.0: 17%
+[1A[K(1/6) Downloading Xcode 0.0.0: 18%
+[1A[K(1/6) Downloading Xcode 0.0.0: 19%
+[1A[K(1/6) Downloading Xcode 0.0.0: 20%
+[1A[K(1/6) Downloading Xcode 0.0.0: 21%
+[1A[K(1/6) Downloading Xcode 0.0.0: 22%
+[1A[K(1/6) Downloading Xcode 0.0.0: 23%
+[1A[K(1/6) Downloading Xcode 0.0.0: 24%
+[1A[K(1/6) Downloading Xcode 0.0.0: 25%
+[1A[K(1/6) Downloading Xcode 0.0.0: 26%
+[1A[K(1/6) Downloading Xcode 0.0.0: 27%
+[1A[K(1/6) Downloading Xcode 0.0.0: 28%
+[1A[K(1/6) Downloading Xcode 0.0.0: 29%
+[1A[K(1/6) Downloading Xcode 0.0.0: 30%
+[1A[K(1/6) Downloading Xcode 0.0.0: 31%
+[1A[K(1/6) Downloading Xcode 0.0.0: 32%
+[1A[K(1/6) Downloading Xcode 0.0.0: 33%
+[1A[K(1/6) Downloading Xcode 0.0.0: 34%
+[1A[K(1/6) Downloading Xcode 0.0.0: 35%
+[1A[K(1/6) Downloading Xcode 0.0.0: 36%
+[1A[K(1/6) Downloading Xcode 0.0.0: 37%
+[1A[K(1/6) Downloading Xcode 0.0.0: 38%
+[1A[K(1/6) Downloading Xcode 0.0.0: 39%
+[1A[K(1/6) Downloading Xcode 0.0.0: 40%
+[1A[K(1/6) Downloading Xcode 0.0.0: 41%
+[1A[K(1/6) Downloading Xcode 0.0.0: 42%
+[1A[K(1/6) Downloading Xcode 0.0.0: 43%
+[1A[K(1/6) Downloading Xcode 0.0.0: 44%
+[1A[K(1/6) Downloading Xcode 0.0.0: 45%
+[1A[K(1/6) Downloading Xcode 0.0.0: 46%
+[1A[K(1/6) Downloading Xcode 0.0.0: 47%
+[1A[K(1/6) Downloading Xcode 0.0.0: 48%
+[1A[K(1/6) Downloading Xcode 0.0.0: 49%
+[1A[K(1/6) Downloading Xcode 0.0.0: 50%
+[1A[K(1/6) Downloading Xcode 0.0.0: 51%
+[1A[K(1/6) Downloading Xcode 0.0.0: 52%
+[1A[K(1/6) Downloading Xcode 0.0.0: 53%
+[1A[K(1/6) Downloading Xcode 0.0.0: 54%
+[1A[K(1/6) Downloading Xcode 0.0.0: 55%
+[1A[K(1/6) Downloading Xcode 0.0.0: 56%
+[1A[K(1/6) Downloading Xcode 0.0.0: 57%
+[1A[K(1/6) Downloading Xcode 0.0.0: 58%
+[1A[K(1/6) Downloading Xcode 0.0.0: 59%
+[1A[K(1/6) Downloading Xcode 0.0.0: 60%
+[1A[K(1/6) Downloading Xcode 0.0.0: 61%
+[1A[K(1/6) Downloading Xcode 0.0.0: 62%
+[1A[K(1/6) Downloading Xcode 0.0.0: 63%
+[1A[K(1/6) Downloading Xcode 0.0.0: 64%
+[1A[K(1/6) Downloading Xcode 0.0.0: 65%
+[1A[K(1/6) Downloading Xcode 0.0.0: 66%
+[1A[K(1/6) Downloading Xcode 0.0.0: 67%
+[1A[K(1/6) Downloading Xcode 0.0.0: 68%
+[1A[K(1/6) Downloading Xcode 0.0.0: 69%
+[1A[K(1/6) Downloading Xcode 0.0.0: 70%
+[1A[K(1/6) Downloading Xcode 0.0.0: 71%
+[1A[K(1/6) Downloading Xcode 0.0.0: 72%
+[1A[K(1/6) Downloading Xcode 0.0.0: 73%
+[1A[K(1/6) Downloading Xcode 0.0.0: 74%
+[1A[K(1/6) Downloading Xcode 0.0.0: 75%
+[1A[K(1/6) Downloading Xcode 0.0.0: 76%
+[1A[K(1/6) Downloading Xcode 0.0.0: 77%
+[1A[K(1/6) Downloading Xcode 0.0.0: 78%
+[1A[K(1/6) Downloading Xcode 0.0.0: 79%
+[1A[K(1/6) Downloading Xcode 0.0.0: 80%
+[1A[K(1/6) Downloading Xcode 0.0.0: 81%
+[1A[K(1/6) Downloading Xcode 0.0.0: 82%
+[1A[K(1/6) Downloading Xcode 0.0.0: 83%
+[1A[K(1/6) Downloading Xcode 0.0.0: 84%
+[1A[K(1/6) Downloading Xcode 0.0.0: 85%
+[1A[K(1/6) Downloading Xcode 0.0.0: 86%
+[1A[K(1/6) Downloading Xcode 0.0.0: 87%
+[1A[K(1/6) Downloading Xcode 0.0.0: 88%
+[1A[K(1/6) Downloading Xcode 0.0.0: 89%
+[1A[K(1/6) Downloading Xcode 0.0.0: 90%
+[1A[K(1/6) Downloading Xcode 0.0.0: 91%
+[1A[K(1/6) Downloading Xcode 0.0.0: 92%
+[1A[K(1/6) Downloading Xcode 0.0.0: 93%
+[1A[K(1/6) Downloading Xcode 0.0.0: 94%
+[1A[K(1/6) Downloading Xcode 0.0.0: 95%
+[1A[K(1/6) Downloading Xcode 0.0.0: 96%
+[1A[K(1/6) Downloading Xcode 0.0.0: 97%
+[1A[K(1/6) Downloading Xcode 0.0.0: 98%
+[1A[K(1/6) Downloading Xcode 0.0.0: 99%
+[1A[K(1/6) Downloading Xcode 0.0.0: 100%
+(2/6) Unarchiving Xcode (This can take a while)
+(3/6) Moving Xcode to /Applications/Xcode-0.0.0.app
+(4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
+(5/6) Checking security assessment and code signing
+(6/6) Finishing installation
+xcodes requires superuser privileges in order to finish installation.
+macOS User Password: 
+
+Xcode 0.0.0 has been installed to /Applications/Xcode-0.0.0.app

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -210,6 +210,122 @@ final class XcodesKitTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
+    func test_InstallLogging_IncorrectSavedPassword() {
+        var log = ""
+        XcodesKit.Current.logging.log = { log.append($0 + "\n") }
+
+        // Don't have a valid session
+        Current.network.validateSession = { Promise(error: AppleAPI.Client.Error.invalidSession) }
+        // XCODES_PASSWORD has incorrect password
+        var passwordEnvCallCount = 0
+        XcodesKit.Current.shell.env = { key in
+            if key == "XCODES_PASSWORD" {
+                passwordEnvCallCount += 1
+                return "old_password" 
+            } else {
+                return nil 
+            }
+        }
+        var loginCallCount = 0
+        XcodesKit.Current.network.login = { _, _ in
+            defer { loginCallCount += 1 }
+            if loginCallCount == 0 {
+                return Promise(error: Client.Error.invalidUsernameOrPassword(username: "test@example.com"))
+            }
+            return Promise.value(())
+        }
+        // It hasn't been downloaded
+        Current.files.fileExistsAtPath = { path in
+            if path == (Path.xcodesApplicationSupport/"Xcode-0.0.0.xip").string {
+                return false
+            }
+            else {
+                return true
+            }
+        }
+        // It's an available release version
+        XcodesKit.Current.network.dataTask = { url in
+            if url.pmkRequest.url! == URLRequest.downloads.url! {
+                let downloads = Downloads(downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip")], dateModified: Date())])
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .formatted(.downloadsDateModified)
+                let downloadsData = try! encoder.encode(downloads)
+                return Promise.value((data: downloadsData, response: HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+            }
+
+            return Promise.value((data: Data(), response: HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+        }
+        // It downloads and updates progress
+        Current.network.downloadTask = { (url, saveLocation, _) -> (Progress, Promise<(saveLocation: URL, response: URLResponse)>) in
+            let progress = Progress(totalUnitCount: 100)
+            return (progress,
+                    Promise { resolver in
+                        // Need this to run after the Promise has returned to the caller. This makes the test async, requiring waiting for an expectation.
+                        DispatchQueue.main.async {
+                            for i in 0...100 {
+                                progress.completedUnitCount = Int64(i)
+                            }
+                            resolver.fulfill((saveLocation: saveLocation,
+                                              response: HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+                        }
+                    })
+        }
+        // It's a valid .app
+        Current.shell.codesignVerify = { _ in
+            return Promise.value(
+                ProcessOutput(
+                    status: 0,
+                    out: "",
+                    err: """
+                        TeamIdentifier=\(XcodeInstaller.XcodeTeamIdentifier)
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[0])
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[1])
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[2])
+                        """))
+        }
+        // Don't have superuser privileges the first time
+        var validateSudoAuthenticationCallCount = 0
+        XcodesKit.Current.shell.validateSudoAuthentication = {
+            validateSudoAuthenticationCallCount += 1
+
+            if validateSudoAuthenticationCallCount == 1 {
+                return Promise(error: Process.PMKError.execution(process: Process(), standardOutput: nil, standardError: nil))
+            }
+            else {
+                return Promise.value(Shell.processOutputMock)
+            }
+        }
+        // User enters password
+        var readSecureLineCallCount = 0
+        XcodesKit.Current.shell.readSecureLine = { prompt, _ in
+            XcodesKit.Current.logging.log(prompt)
+            readSecureLineCallCount += 1
+            return "password"
+        }
+        // User enters something
+        XcodesKit.Current.shell.readLine = { prompt in
+            XcodesKit.Current.logging.log(prompt)
+            return "test@example.com"
+        }
+
+        let expectation = self.expectation(description: "Finished")
+
+        installer.install(.version("0.0.0"), downloader: .urlSession)
+            .ensure {
+                let url = Bundle.module.url(forResource: "LogOutput-IncorrectSavedPassword", withExtension: "txt", subdirectory: "Fixtures")!
+                XCTAssertEqual(log, try! String(contentsOf: url))
+                expectation.fulfill()
+
+                XCTAssertEqual(passwordEnvCallCount, 2)
+                XCTAssertEqual(readSecureLineCallCount, 2)
+            }
+            .catch {
+                XCTFail($0.localizedDescription)
+            }
+
+        waitForExpectations(timeout: 1.0)
+    }
+    
     func test_InstallLogging_DamagedXIP() {
         var log = ""
         XcodesKit.Current.logging.log = { log.append($0 + "\n") }


### PR DESCRIPTION
If the ENV password is incorrect, the `loginWithNeeded` method will fail in a recurring loop. This change will ensure that STDIN input is required if authentication fails the first time. Also, the current username is printed out on the password input line for improved clarity.