### PR TITLE
Add directory argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Install a specific version of Xcode using a command like one of these:
 xcodes install 10.2.1
 xcodes install 11 Beta 7
 xcodes install 11.2 GM seed
-xcodes install --latest
+xcodes install 9.0 --path ~/Archive/Xcode_9.xip
+xcodes install --latest-prerelease
+xcodes install --latest --directory "/Volumes/Bag Of Holding/"
 ```
 
 You'll then be prompted to enter your Apple ID username and password. You can also provide these with the `XCODES_USERNAME` and `XCODES_PASSWORD` environment variables.
@@ -87,6 +89,8 @@ Xcode 11.2.0 has been installed to /Applications/Xcode-11.2.0.app
 ```
 
 If you have [aria2](https://aria2.github.io) installed (it's available in Homebrew, `brew install aria2`), then xcodes will default to use it for downloads. It uses up to 16 connections to download Xcode 3-5x faster than URLSession.
+
+Xcode will be installed to /Applications by default, but you can provide the path to a different directory with the `--directory` option or the `XCODES_DIRECTORY` environment variable. All of the xcodes commands support this option, like `select` and `uninstall`, so you can manage Xcode versions that aren't in /Applications. xcodes supports having all of your Xcode versions installed in _one_ directory, wherever that may be.
 
 ### Commands
 

--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -238,8 +238,8 @@ public struct Files {
 
     public var installedXcodes = XcodesKit.installedXcodes
 }
-private func installedXcodes() -> [InstalledXcode] {
-    ((try? Path.root.join("Applications").ls()) ?? [])
+private func installedXcodes(directory: Path) -> [InstalledXcode] {
+    ((try? directory.ls()) ?? [])
         .filter { $0.isAppBundle && $0.infoPlist?.bundleID == "com.apple.dt.Xcode" }
         .map { $0.path }
         .compactMap(InstalledXcode.init)

--- a/Tests/XcodesKitTests/Environment+Mock.swift
+++ b/Tests/XcodesKitTests/Environment+Mock.swift
@@ -59,7 +59,7 @@ extension Files {
         trashItem: { _ in return URL(fileURLWithPath: "\(NSHomeDirectory())/.Trash") },
         createFile: { _, _, _ in return true },
         createDirectory: { _, _, _ in },
-        installedXcodes: { [] }
+        installedXcodes: { _ in [] }
     )
 }
 

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-AlternativeDirectory.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-AlternativeDirectory.txt
@@ -1,0 +1,112 @@
+Apple ID: 
+Apple ID Password: 
+
+[1A[K(1/6) Downloading Xcode 0.0.0: 1%
+[1A[K(1/6) Downloading Xcode 0.0.0: 2%
+[1A[K(1/6) Downloading Xcode 0.0.0: 3%
+[1A[K(1/6) Downloading Xcode 0.0.0: 4%
+[1A[K(1/6) Downloading Xcode 0.0.0: 5%
+[1A[K(1/6) Downloading Xcode 0.0.0: 6%
+[1A[K(1/6) Downloading Xcode 0.0.0: 7%
+[1A[K(1/6) Downloading Xcode 0.0.0: 8%
+[1A[K(1/6) Downloading Xcode 0.0.0: 9%
+[1A[K(1/6) Downloading Xcode 0.0.0: 10%
+[1A[K(1/6) Downloading Xcode 0.0.0: 11%
+[1A[K(1/6) Downloading Xcode 0.0.0: 12%
+[1A[K(1/6) Downloading Xcode 0.0.0: 13%
+[1A[K(1/6) Downloading Xcode 0.0.0: 14%
+[1A[K(1/6) Downloading Xcode 0.0.0: 15%
+[1A[K(1/6) Downloading Xcode 0.0.0: 16%
+[1A[K(1/6) Downloading Xcode 0.0.0: 17%
+[1A[K(1/6) Downloading Xcode 0.0.0: 18%
+[1A[K(1/6) Downloading Xcode 0.0.0: 19%
+[1A[K(1/6) Downloading Xcode 0.0.0: 20%
+[1A[K(1/6) Downloading Xcode 0.0.0: 21%
+[1A[K(1/6) Downloading Xcode 0.0.0: 22%
+[1A[K(1/6) Downloading Xcode 0.0.0: 23%
+[1A[K(1/6) Downloading Xcode 0.0.0: 24%
+[1A[K(1/6) Downloading Xcode 0.0.0: 25%
+[1A[K(1/6) Downloading Xcode 0.0.0: 26%
+[1A[K(1/6) Downloading Xcode 0.0.0: 27%
+[1A[K(1/6) Downloading Xcode 0.0.0: 28%
+[1A[K(1/6) Downloading Xcode 0.0.0: 29%
+[1A[K(1/6) Downloading Xcode 0.0.0: 30%
+[1A[K(1/6) Downloading Xcode 0.0.0: 31%
+[1A[K(1/6) Downloading Xcode 0.0.0: 32%
+[1A[K(1/6) Downloading Xcode 0.0.0: 33%
+[1A[K(1/6) Downloading Xcode 0.0.0: 34%
+[1A[K(1/6) Downloading Xcode 0.0.0: 35%
+[1A[K(1/6) Downloading Xcode 0.0.0: 36%
+[1A[K(1/6) Downloading Xcode 0.0.0: 37%
+[1A[K(1/6) Downloading Xcode 0.0.0: 38%
+[1A[K(1/6) Downloading Xcode 0.0.0: 39%
+[1A[K(1/6) Downloading Xcode 0.0.0: 40%
+[1A[K(1/6) Downloading Xcode 0.0.0: 41%
+[1A[K(1/6) Downloading Xcode 0.0.0: 42%
+[1A[K(1/6) Downloading Xcode 0.0.0: 43%
+[1A[K(1/6) Downloading Xcode 0.0.0: 44%
+[1A[K(1/6) Downloading Xcode 0.0.0: 45%
+[1A[K(1/6) Downloading Xcode 0.0.0: 46%
+[1A[K(1/6) Downloading Xcode 0.0.0: 47%
+[1A[K(1/6) Downloading Xcode 0.0.0: 48%
+[1A[K(1/6) Downloading Xcode 0.0.0: 49%
+[1A[K(1/6) Downloading Xcode 0.0.0: 50%
+[1A[K(1/6) Downloading Xcode 0.0.0: 51%
+[1A[K(1/6) Downloading Xcode 0.0.0: 52%
+[1A[K(1/6) Downloading Xcode 0.0.0: 53%
+[1A[K(1/6) Downloading Xcode 0.0.0: 54%
+[1A[K(1/6) Downloading Xcode 0.0.0: 55%
+[1A[K(1/6) Downloading Xcode 0.0.0: 56%
+[1A[K(1/6) Downloading Xcode 0.0.0: 57%
+[1A[K(1/6) Downloading Xcode 0.0.0: 58%
+[1A[K(1/6) Downloading Xcode 0.0.0: 59%
+[1A[K(1/6) Downloading Xcode 0.0.0: 60%
+[1A[K(1/6) Downloading Xcode 0.0.0: 61%
+[1A[K(1/6) Downloading Xcode 0.0.0: 62%
+[1A[K(1/6) Downloading Xcode 0.0.0: 63%
+[1A[K(1/6) Downloading Xcode 0.0.0: 64%
+[1A[K(1/6) Downloading Xcode 0.0.0: 65%
+[1A[K(1/6) Downloading Xcode 0.0.0: 66%
+[1A[K(1/6) Downloading Xcode 0.0.0: 67%
+[1A[K(1/6) Downloading Xcode 0.0.0: 68%
+[1A[K(1/6) Downloading Xcode 0.0.0: 69%
+[1A[K(1/6) Downloading Xcode 0.0.0: 70%
+[1A[K(1/6) Downloading Xcode 0.0.0: 71%
+[1A[K(1/6) Downloading Xcode 0.0.0: 72%
+[1A[K(1/6) Downloading Xcode 0.0.0: 73%
+[1A[K(1/6) Downloading Xcode 0.0.0: 74%
+[1A[K(1/6) Downloading Xcode 0.0.0: 75%
+[1A[K(1/6) Downloading Xcode 0.0.0: 76%
+[1A[K(1/6) Downloading Xcode 0.0.0: 77%
+[1A[K(1/6) Downloading Xcode 0.0.0: 78%
+[1A[K(1/6) Downloading Xcode 0.0.0: 79%
+[1A[K(1/6) Downloading Xcode 0.0.0: 80%
+[1A[K(1/6) Downloading Xcode 0.0.0: 81%
+[1A[K(1/6) Downloading Xcode 0.0.0: 82%
+[1A[K(1/6) Downloading Xcode 0.0.0: 83%
+[1A[K(1/6) Downloading Xcode 0.0.0: 84%
+[1A[K(1/6) Downloading Xcode 0.0.0: 85%
+[1A[K(1/6) Downloading Xcode 0.0.0: 86%
+[1A[K(1/6) Downloading Xcode 0.0.0: 87%
+[1A[K(1/6) Downloading Xcode 0.0.0: 88%
+[1A[K(1/6) Downloading Xcode 0.0.0: 89%
+[1A[K(1/6) Downloading Xcode 0.0.0: 90%
+[1A[K(1/6) Downloading Xcode 0.0.0: 91%
+[1A[K(1/6) Downloading Xcode 0.0.0: 92%
+[1A[K(1/6) Downloading Xcode 0.0.0: 93%
+[1A[K(1/6) Downloading Xcode 0.0.0: 94%
+[1A[K(1/6) Downloading Xcode 0.0.0: 95%
+[1A[K(1/6) Downloading Xcode 0.0.0: 96%
+[1A[K(1/6) Downloading Xcode 0.0.0: 97%
+[1A[K(1/6) Downloading Xcode 0.0.0: 98%
+[1A[K(1/6) Downloading Xcode 0.0.0: 99%
+[1A[K(1/6) Downloading Xcode 0.0.0: 100%
+(2/6) Unarchiving Xcode (This can take a while)
+(3/6) Moving Xcode to /Users/brandon/Xcode/Xcode-0.0.0.app
+(4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
+(5/6) Checking security assessment and code signing
+(6/6) Finishing installation
+xcodes requires superuser privileges in order to finish installation.
+macOS User Password: 
+
+Xcode 0.0.0 has been installed to /Users/brandon/Xcode/Xcode-0.0.0.app


### PR DESCRIPTION
This adds a directory argument at the top level (so it affects all commands) which determines the directory that xcodes installs in to. It defaults to /Applications, which is the current behaviour. xcodes will also check for a value in the XCODES_DIRECTORY environment variable. It applies to installation but also the other commands, so that e.g. selecting or uninstalling a version looks in the desired directory.

The motivation for all of this is to support users that may not want to store Xcode versions in /Applications, for example if they don't have enough space on their boot volume.

This also aligns with the addition of the directory argument as part of #121.

## Testing

First, clone this repo if necessary and check out the PR branch:

```
git clone https://github.com/RobotsAndPencils/xcodes.git
cd xcodes
git checkout -b interstateone-xcodes-destination master
git pull https://github.com/interstateone/xcodes.git xcodes-destination
```

then run commands with either the directory argument or XCODES_DIRECTORY environment variable set. If it's set to a directory that doesn't exist, or to a path that isn't a directory, it should print an error.

Expected results:

```
❯ swift run xcodes list --directory /Users/brandon/Xcodes
Directory argument must be a directory, but was provided /Users/brandon/Xcodes.

# make sure the directory exists
❯ mkdir /Users/brandon/Xcodes

# it doesn't have any Xcodes in it yet
❯ swift run xcodes installed --directory /Users/Brandon/Xcodes

# download command still works like before
❯ swift run xcodes download 12.3 --directory /Users/brandon/Xcodes
(1/1) Downloading Xcode 12.3.0: 99%

Xcode 12.3.0 has been downloaded to /Users/brandon/Xcodes/Xcode-12.3.0.xip

❯ ls /Users/brandon/Xcodes | grep Xcode                               
-rw-r--r--   1 brandon  staff    11G  2 Jan 11:19 Xcode-12.3.0.xip

# install works
❯ XCODES_DIRECTORY=/Users/brandon/Xcodes swift run xcodes install 12.2                                  
(1/6) Downloading Xcode 12.2.0: 99%
(2/6) Unarchiving Xcode (This can take a while)
(3/6) Moving Xcode to /Users/brandon/Xcodes/Xcode-12.2.0.app
(4/6) Moving Xcode archive Xcode-12.2.0.xip to the Trash
(5/6) Checking security assessment and code signing
(6/6) Finishing installation
xcodes requires superuser privileges in order to finish installation.
macOS User Password: 

Xcode 12.2.0 has been installed to /Users/brandon/Xcodes/Xcode-12.2.0.app

❯ ls /Users/brandon/Xcodes | grep Xcode
drwxr-xr-x   3 brandon  staff    96B 23 Oct 20:24 Xcode-12.2.0.app
-rw-r--r--   1 brandon  staff    11G  2 Jan 11:19 Xcode-12.3.0.xip
```

---

Closes #100