### PR TITLE
Add support for and default to Xcode Releases data source

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "XcodeReleases",
+        "repositoryURL": "https://github.com/xcodereleases/data",
+        "state": {
+          "branch": null,
+          "revision": "b47228c688b608e34b3b84079ab6052a24c7a981",
+          "version": null
+        }
+      },
+      {
         "package": "PMKFoundation",
         "repositoryURL": "https://github.com/PromiseKit/Foundation.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,25 +20,38 @@ let package = Package(
         .package(url: "https://github.com/scinfu/SwiftSoup.git", .upToNextMinor(from: "2.0.0")),
         .package(url: "https://github.com/mxcl/LegibleError.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.2.0")),
+        .package(name: "XcodeReleases", url: "https://github.com/xcodereleases/data", .revision("b47228c688b608e34b3b84079ab6052a24c7a981")),
     ],
     targets: [
         .target(
             name: "xcodes",
             dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser"), "XcodesKit"
+                .product(name: "ArgumentParser", package: "swift-argument-parser"), 
+                "XcodesKit"
             ]),
         .testTarget(
             name: "xcodesTests",
-            dependencies: ["xcodes"]),
+            dependencies: [
+                "xcodes"
+            ]),
         .target(
             name: "XcodesKit",
             dependencies: [
-                "AppleAPI", .product(name: "Path", package: "Path.swift"), "Version", "PromiseKit", "PMKFoundation", "SwiftSoup", "LegibleError", "KeychainAccess"
+                "AppleAPI", 
+                "KeychainAccess",
+                "LegibleError",
+                .product(name: "Path", package: "Path.swift"), 
+                "PromiseKit", 
+                "PMKFoundation", 
+                "SwiftSoup",
+                "Version", 
+                .product(name: "XCModel", package: "XcodeReleases"),
             ]),
         .testTarget(
             name: "XcodesKitTests",
             dependencies: [
-                "XcodesKit", "Version"
+                "XcodesKit",
+                "Version"
             ],
             resources: [
                 .copy("Fixtures"),
@@ -46,11 +59,14 @@ let package = Package(
         .target(
             name: "AppleAPI",
             dependencies: [
-                "PromiseKit", "PMKFoundation"
+                "PromiseKit",
+                "PMKFoundation"
             ]),
         .testTarget(
             name: "AppleAPITests",
-            dependencies: ["AppleAPI"],
+            dependencies: [
+                "AppleAPI"
+            ],
             resources: [
                 .copy("Fixtures"),
             ]),

--- a/Sources/XcodesKit/DataSource.swift
+++ b/Sources/XcodesKit/DataSource.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum DataSource: String, CaseIterable {
+    case apple
+    case xcodeReleases
+}

--- a/Sources/XcodesKit/Models+FirstWithVersion.swift
+++ b/Sources/XcodesKit/Models+FirstWithVersion.swift
@@ -3,20 +3,20 @@ import Version
 
 /// Returns the first XcodeType that unambiguously has the same version as `version`.
 ///
-/// If there's an exact match that takes prerelease identifiers into account, that's returned.
+/// If there's an equivalent match that takes prerelease identifiers into account, that's returned.
 /// Otherwise, if a version without prerelease or build metadata identifiers is provided, and there's a single match based on only the major, minor and patch numbers, that's returned.
 /// If there are multiple matches, or no matches, nil is returned.
 public func findXcode<XcodeType>(version: Version, in xcodes: [XcodeType], versionKeyPath: KeyPath<XcodeType, Version>) -> XcodeType? {
-    // Look for the exact provided version first
-    if let installedXcode = xcodes.first(where: { $0[keyPath: versionKeyPath].isEqualWithoutBuildMetadataIdentifiers(to: version) }) {
-        return installedXcode
+    // Look for the equivalent provided version first
+    if let equivalentXcode = xcodes.first(where: { $0[keyPath: versionKeyPath].isEquivalent(to: version) }) {
+        return equivalentXcode
     }
-    // If a short version is provided, look again for a match, ignore all
-    // identifiers this time. Ignore if there are more than one match.
+    // If a version without prerelease or build identifiers is provided, then ignore all identifiers this time. 
+    // There must be exactly one match.
     else if version.prereleaseIdentifiers.isEmpty && version.buildMetadataIdentifiers.isEmpty,
         xcodes.filter({ $0[keyPath: versionKeyPath].isEqualWithoutAllIdentifiers(to: version) }).count == 1 {
-        let installedXcode = xcodes.first(where: { $0[keyPath: versionKeyPath].isEqualWithoutAllIdentifiers(to: version) })!
-        return installedXcode
+        let matchedXcode = xcodes.first(where: { $0[keyPath: versionKeyPath].isEqualWithoutAllIdentifiers(to: version) })!
+        return matchedXcode
     } else {
         return nil
     }
@@ -42,4 +42,12 @@ public extension Array where Element == InstalledXcode {
     func first(withVersion version: Version) -> InstalledXcode? {
         findXcode(version: version, in: self, versionKeyPath: \.version)
     } 
+}
+
+extension Version {
+    func isEqualWithoutAllIdentifiers(to other: Version) -> Bool {
+        return major == other.major &&
+               minor == other.minor &&
+               patch == other.patch
+    }
 }

--- a/Sources/XcodesKit/Version+.swift
+++ b/Sources/XcodesKit/Version+.swift
@@ -1,47 +1,24 @@
 import Version
 
 public extension Version {
-    func isEqualWithoutBuildMetadataIdentifiers(to other: Version) -> Bool {
-        return major == other.major && 
-               minor == other.minor &&
-               patch == other.patch &&
-               prereleaseIdentifiers == other.prereleaseIdentifiers
-    }
-
-    func isEqualWithoutAllIdentifiers(to other: Version) -> Bool {
-        return major == other.major &&
-               minor == other.minor &&
-               patch == other.patch
-    }
-
-    /// If release versions, don't compare build metadata because that's not provided in the /downloads/more list
-    /// if beta versions, compare build metadata because it's available in versions.plist
-    func isEquivalentForDeterminingIfInstalled(toInstalled installed: Version) -> Bool {
-        let isBeta = !prereleaseIdentifiers.isEmpty
-        let otherIsBeta = !installed.prereleaseIdentifiers.isEmpty
-
-        if isBeta && otherIsBeta {
-            if buildMetadataIdentifiers.isEmpty {
-                return major == installed.major &&
-                       minor == installed.minor &&
-                       patch == installed.patch &&
-                       prereleaseIdentifiers == installed.prereleaseIdentifiers
-            }
-            else {
-                return major == installed.major &&
-                       minor == installed.minor &&
-                       patch == installed.patch &&
-                       prereleaseIdentifiers == installed.prereleaseIdentifiers &&
-                       buildMetadataIdentifiers.map { $0.lowercased() } == installed.buildMetadataIdentifiers.map { $0.lowercased() }
-            }
+    /// Determines if two Xcode versions should be treated equivalently. This is not the same as equality.
+    /// 
+    /// We need a way to determine if two Xcode versions are the same without always having full information, and supporting different data sources.
+    /// For example, the Apple data source often doesn't have build metadata identifiers.  
+    func isEquivalent(to other: Version) -> Bool {
+        // If we don't have build metadata identifiers for both Versions, compare major, minor, patch and prerelease identifiers.
+        if buildMetadataIdentifiers.isEmpty || other.buildMetadataIdentifiers.isEmpty {
+            return major == other.major &&
+                   minor == other.minor &&
+                   patch == other.patch &&
+                   prereleaseIdentifiers.map { $0.lowercased() } == other.prereleaseIdentifiers.map { $0.lowercased() }
+        // If we have build metadata identifiers for both, we can ignore the prerelease identifiers.
+        } else {
+            return major == other.major &&
+                   minor == other.minor &&
+                   patch == other.patch && 
+                   buildMetadataIdentifiers.map { $0.lowercased() } == other.buildMetadataIdentifiers.map { $0.lowercased() }
         }
-        else if !isBeta && !otherIsBeta {
-            return major == installed.major && 
-                   minor == installed.minor &&
-                   patch == installed.patch
-        }
-
-        return false
     }
 
     var descriptionWithoutBuildMetadata: String {

--- a/Sources/XcodesKit/Version+.swift
+++ b/Sources/XcodesKit/Version+.swift
@@ -8,15 +8,11 @@ public extension Version {
     func isEquivalent(to other: Version) -> Bool {
         // If we don't have build metadata identifiers for both Versions, compare major, minor, patch and prerelease identifiers.
         if buildMetadataIdentifiers.isEmpty || other.buildMetadataIdentifiers.isEmpty {
-            return major == other.major &&
-                   minor == other.minor &&
-                   patch == other.patch &&
+            return isEqualWithoutAllIdentifiers(to: other) &&
                    prereleaseIdentifiers.map { $0.lowercased() } == other.prereleaseIdentifiers.map { $0.lowercased() }
         // If we have build metadata identifiers for both, we can ignore the prerelease identifiers.
         } else {
-            return major == other.major &&
-                   minor == other.minor &&
-                   patch == other.patch && 
+            return isEqualWithoutAllIdentifiers(to: other) && 
                    buildMetadataIdentifiers.map { $0.lowercased() } == other.buildMetadataIdentifiers.map { $0.lowercased() }
         }
     }

--- a/Sources/XcodesKit/Version+Xcode.swift
+++ b/Sources/XcodesKit/Version+Xcode.swift
@@ -38,21 +38,31 @@ public extension Version {
         self = Version(major: major, minor: minor, patch: patch, prereleaseIdentifiers: prereleaseIdentifiers, buildMetadataIdentifiers: [buildMetadataIdentifier].compactMap { $0 })
     }
 
-    var xcodeDescription: String {
+    /// The intent here is to match Apple's marketing version
+    ///
+    /// Only show the patch number if it's not 0
+    /// Format prerelease identifiers
+    /// Don't include build identifiers
+    var appleDescription: String {
         var base = "\(major).\(minor)"
         if patch != 0 {
             base += ".\(patch)"
         }
         if !prereleaseIdentifiers.isEmpty {
             base += " " + prereleaseIdentifiers
-                .map { $0.replacingOccurrences(of: "-", with: " ").capitalized.replacingOccurrences(of: "Gm", with: "GM") }
+                .map { identifier in
+                    identifier
+                        .replacingOccurrences(of: "-", with: " ")
+                        .capitalized
+                        .replacingOccurrences(of: "Gm", with: "GM")
+                        .replacingOccurrences(of: "Rc", with: "RC")
+                }
                 .joined(separator: " ")
-
-            if !buildMetadataIdentifiers.isEmpty {
-                base += " (\(buildMetadataIdentifiers.joined(separator: " ")))"
-            }
         }
         return base
+    }
+    var appleDescriptionWithBuildIdentifier: String {
+        [appleDescription, buildMetadataIdentifiersDisplay].filter { !$0.isEmpty }.joined(separator: " ")
     }
 }
 

--- a/Sources/XcodesKit/Version+Xcode.swift
+++ b/Sources/XcodesKit/Version+Xcode.swift
@@ -16,8 +16,8 @@ public extension Version {
      */
     init?(xcodeVersion: String, buildMetadataIdentifier: String? = nil) {
         let nsrange = NSRange(xcodeVersion.startIndex..<xcodeVersion.endIndex, in: xcodeVersion)
-        // https://regex101.com/r/dLLvsz/1
-        let pattern = "^(Xcode )?(?<major>\\d+)\\.?(?<minor>\\d?)\\.?(?<patch>\\d?) ?(?<prereleaseType>[a-zA-Z ]+)? ?(?<prereleaseVersion>\\d?)"
+        // https://regex101.com/r/K7530Z/1
+        let pattern = "^(Xcode )?(?<major>\\d+)\\.?(?<minor>\\d*)\\.?(?<patch>\\d*) ?(?<prereleaseType>[a-zA-Z ]+)? ?(?<prereleaseVersion>\\d*)"
 
         guard
             let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),

--- a/Sources/XcodesKit/Version+XcodeReleases.swift
+++ b/Sources/XcodesKit/Version+XcodeReleases.swift
@@ -1,0 +1,54 @@
+import Version
+import struct XCModel.Xcode
+
+extension Version {
+    /// Initialize a Version from an XcodeReleases' XCModel.Xcode
+    ///
+    /// This is kinda quick-and-dirty, and it would probably be better for us to adopt something closer to XCModel.Xcode under the hood and map the scraped data to it instead.
+    init?(xcReleasesXcode: XCModel.Xcode) {
+        var versionString = xcReleasesXcode.version.number ?? ""
+        
+        // Append trailing ".0" in order to get a fully-specified version string
+        let components = versionString.components(separatedBy: ".")
+        versionString += Array(repeating: ".0", count: 3 - components.count).joined()
+        
+        // Append prerelease identifier
+        switch xcReleasesXcode.version.release {
+        case let .beta(beta):
+            versionString += "-Beta"
+            if beta > 1 {
+                versionString += ".\(beta)"
+            }
+        case let .dp(dp):
+            versionString += "-DP"
+            if dp > 1 {
+                versionString += ".\(dp)"
+            }
+        case .gm:
+            versionString += "-GM"
+        case let .gmSeed(gmSeed):
+            versionString += "-GM.Seed"
+            if gmSeed > 1 {
+                versionString += ".\(gmSeed)"
+            }
+        case let .rc(rc):
+            versionString += "-Release.Candidate"
+            if rc > 1 {
+                versionString += ".\(rc)"
+            }
+        case .release:
+            break
+        }
+        
+        // Append build identifier
+        if let buildNumber = xcReleasesXcode.version.build {
+            versionString += "+\(buildNumber)"
+        }
+        
+        self.init(versionString)
+    }
+    
+    var buildMetadataIdentifiersDisplay: String {
+        return !buildMetadataIdentifiers.isEmpty ? "(\(buildMetadataIdentifiers.joined(separator: " ")))" : ""
+    }
+}

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -284,6 +284,14 @@ public final class XcodeInstaller {
                 return Promise.value(version)
             }
         }
+        .then { version -> Promise<Version> in
+            // This request would've already been made if the Apple data source were being used.
+            // That's not the case for the Xcode Releases data source.
+            // We need the cookies from its response in order to download Xcodes though,
+            // so perform it here first just to be sure.
+            Current.network.dataTask(with: URLRequest.downloads)
+                .map { _ in version }
+        }
         .then { version -> Promise<(Xcode, URL)> in
             guard let xcode = self.xcodeList.availableXcodes.first(withVersion: version) else {
                 throw Error.unavailableVersion(version)

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -58,7 +58,7 @@ public final class XcodeInstaller {
             case .missingSudoerPassword:
                 return "Missing password. Please try again."
             case let .unavailableVersion(version):
-                return "Could not find version \(version.xcodeDescription)."
+                return "Could not find version \(version.appleDescription)."
             case .noNonPrereleaseVersionAvailable:
                 return "No non-prerelease versions available."
             case .noPrereleaseVersionAvailable:
@@ -66,11 +66,11 @@ public final class XcodeInstaller {
             case .missingUsernameOrPassword:
                 return "Missing username or a password. Please try again."
             case let .versionAlreadyInstalled(installedXcode):
-                return "\(installedXcode.version.xcodeDescription) is already installed at \(installedXcode.path)"
+                return "\(installedXcode.version.appleDescription) is already installed at \(installedXcode.path)"
             case let .invalidVersion(version):
                 return "\(version) is not a valid version number."
             case let .versionNotInstalled(version):
-                return "\(version.xcodeDescription) is not installed."
+                return "\(version.appleDescription) is not installed."
             }
         }
     }
@@ -217,7 +217,7 @@ public final class XcodeInstaller {
                         guard let latestNonPrereleaseXcode = availableXcodes.filter(\.version.isNotPrerelease).sorted(\.version).last else {
                             throw Error.noNonPrereleaseVersionAvailable
                         }
-                        Current.logging.log("Latest non-prerelease version available is \(latestNonPrereleaseXcode.version.xcodeDescription)")
+                        Current.logging.log("Latest non-prerelease version available is \(latestNonPrereleaseXcode.version.appleDescription)")
                         
                         if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: latestNonPrereleaseXcode.version) }) {
                             throw Error.versionAlreadyInstalled(installedXcode)
@@ -238,7 +238,7 @@ public final class XcodeInstaller {
                         else {
                             throw Error.noNonPrereleaseVersionAvailable
                         }
-                        Current.logging.log("Latest prerelease version available is \(latestPrereleaseXcode.version.xcodeDescription)")
+                        Current.logging.log("Latest prerelease version available is \(latestPrereleaseXcode.version.appleDescription)")
                         
                         if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: latestPrereleaseXcode.version) }) {
                             throw Error.versionAlreadyInstalled(installedXcode)
@@ -554,7 +554,7 @@ public final class XcodeInstaller {
                 }
         }
         .done { (installedXcode, trashURL) in
-            Current.logging.log("Xcode \(installedXcode.version.xcodeDescription) moved to Trash: \(trashURL.path)")
+            Current.logging.log("Xcode \(installedXcode.version.appleDescription) moved to Trash: \(trashURL.path)")
             Current.shell.exit(0)
         }
     }
@@ -614,7 +614,7 @@ public final class XcodeInstaller {
                         return first.version < second.version
                     }
                     .forEach { releasedVersion in
-                        var output = releasedVersion.version.xcodeDescription
+                        var output = releasedVersion.version.appleDescriptionWithBuildIdentifier
                         if installedXcodes.contains(where: { releasedVersion.version.isEquivalentForDeterminingIfInstalled(toInstalled: $0.version) }) {
                             if releasedVersion.version == selectedInstalledXcodeVersion {
                                 output += " (Installed, Selected)"
@@ -634,7 +634,7 @@ public final class XcodeInstaller {
                 Current.files.installedXcodes(directory)
                     .sorted { $0.version < $1.version }
                     .forEach { installedXcode in
-                        var output = installedXcode.version.xcodeDescription
+                        var output = installedXcode.version.appleDescriptionWithBuildIdentifier
                         if pathOutput.out.hasPrefix(installedXcode.path.string) {
                             output += " (Selected)"
                         }

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -219,7 +219,7 @@ public final class XcodeInstaller {
                         }
                         Current.logging.log("Latest non-prerelease version available is \(latestNonPrereleaseXcode.version.appleDescription)")
                         
-                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: latestNonPrereleaseXcode.version) }) {
+                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestNonPrereleaseXcode.version) }) {
                             throw Error.versionAlreadyInstalled(installedXcode)
                         }
 
@@ -240,7 +240,7 @@ public final class XcodeInstaller {
                         }
                         Current.logging.log("Latest prerelease version available is \(latestPrereleaseXcode.version.appleDescription)")
                         
-                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: latestPrereleaseXcode.version) }) {
+                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestPrereleaseXcode.version) }) {
                             throw Error.versionAlreadyInstalled(installedXcode)
                         }
                         
@@ -256,7 +256,7 @@ public final class XcodeInstaller {
                 guard let version = Version(xcodeVersion: versionString) ?? versionFromXcodeVersionFile() else {
                     throw Error.invalidVersion(versionString)
                 }
-                if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: version) }) {
+                if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) }) {
                     throw Error.versionAlreadyInstalled(installedXcode)
                 }
                 return self.downloadXcode(version: version, dataSource: dataSource, downloader: downloader, willInstall: willInstall)
@@ -588,13 +588,13 @@ public final class XcodeInstaller {
         for installedXcode in installedXcodes {
             // If an installed version isn't listed online, add the installed version
             if !allXcodeVersions.contains(where: { releasedVersion in
-                releasedVersion.version.isEquivalentForDeterminingIfInstalled(toInstalled: installedXcode.version)
+                releasedVersion.version.isEquivalent(to: installedXcode.version)
             }) {
                 allXcodeVersions.append(ReleasedVersion(version: installedXcode.version, releaseDate: nil))
             }
             // If an installed version is the same as one that's listed online which doesn't have build metadata, replace it with the installed version with build metadata
             else if let index = allXcodeVersions.firstIndex(where: { releasedVersion in
-                releasedVersion.version.isEquivalentForDeterminingIfInstalled(toInstalled: installedXcode.version) &&
+                releasedVersion.version.isEquivalent(to: installedXcode.version) &&
                 releasedVersion.version.buildMetadataIdentifiers.isEmpty
             }) {
                 allXcodeVersions[index] = ReleasedVersion(version: installedXcode.version, releaseDate: nil)
@@ -615,7 +615,7 @@ public final class XcodeInstaller {
                     }
                     .forEach { releasedVersion in
                         var output = releasedVersion.version.appleDescriptionWithBuildIdentifier
-                        if installedXcodes.contains(where: { releasedVersion.version.isEquivalentForDeterminingIfInstalled(toInstalled: $0.version) }) {
+                        if installedXcodes.contains(where: { releasedVersion.version.isEquivalent(to: $0.version) }) {
                             if releasedVersion.version == selectedInstalledXcodeVersion {
                                 output += " (Installed, Selected)"
                             }

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -27,7 +27,7 @@ public final class XcodeList {
                     // /download/more doesn't include build numbers, so we trust that if the version number and prerelease identifiers are the same that they're the same build.
                     // If an Xcode version is listed on both sites then prefer the one on /download because the build metadata is used to compare against installed Xcodes.
                     let xcodes = releasedXcodes.filter { releasedXcode in
-                        prereleaseXcodes.contains { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: releasedXcode.version) } == false
+                        prereleaseXcodes.contains { $0.version.isEquivalent(to: releasedXcode.version) } == false
                     } + prereleaseXcodes
                     self.availableXcodes = xcodes
                     try? self.cacheAvailableXcodes(xcodes)

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -3,6 +3,7 @@ import Path
 import Version
 import PromiseKit
 import SwiftSoup
+import XCModel
 
 /// Provides lists of available and installed Xcodes
 public final class XcodeList {
@@ -16,20 +17,30 @@ public final class XcodeList {
         return availableXcodes.isEmpty
     }
 
-    public func update() -> Promise<[Xcode]> {
-        return when(fulfilled: releasedXcodes(), prereleaseXcodes())
-            .map { releasedXcodes, prereleaseXcodes in
-                // Starting with Xcode 11 beta 6, developer.apple.com/download and developer.apple.com/download/more both list some pre-release versions of Xcode.
-                // Previously pre-release versions only appeared on developer.apple.com/download.
-                // /download/more doesn't include build numbers, so we trust that if the version number and prerelease identifiers are the same that they're the same build.
-                // If an Xcode version is listed on both sites then prefer the one on /download because the build metadata is used to compare against installed Xcodes.
-                let xcodes = releasedXcodes.filter { releasedXcode in
-                    prereleaseXcodes.contains { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: releasedXcode.version) } == false
-                } + prereleaseXcodes
-                self.availableXcodes = xcodes
-                try? self.cacheAvailableXcodes(xcodes)
-                return xcodes
-            }
+    public func update(dataSource: DataSource) -> Promise<[Xcode]> {
+        switch dataSource {
+        case .apple:
+            return when(fulfilled: releasedXcodes(), prereleaseXcodes())
+                .map { releasedXcodes, prereleaseXcodes in
+                    // Starting with Xcode 11 beta 6, developer.apple.com/download and developer.apple.com/download/more both list some pre-release versions of Xcode.
+                    // Previously pre-release versions only appeared on developer.apple.com/download.
+                    // /download/more doesn't include build numbers, so we trust that if the version number and prerelease identifiers are the same that they're the same build.
+                    // If an Xcode version is listed on both sites then prefer the one on /download because the build metadata is used to compare against installed Xcodes.
+                    let xcodes = releasedXcodes.filter { releasedXcode in
+                        prereleaseXcodes.contains { $0.version.isEqualWithoutBuildMetadataIdentifiers(to: releasedXcode.version) } == false
+                    } + prereleaseXcodes
+                    self.availableXcodes = xcodes
+                    try? self.cacheAvailableXcodes(xcodes)
+                    return xcodes
+                }
+        case .xcodeReleases:
+            return xcodeReleases()
+                .map { xcodes in
+                    self.availableXcodes = xcodes
+                    try? self.cacheAvailableXcodes(xcodes)
+                    return xcodes
+                }
+        }
     }
 }
 
@@ -49,6 +60,8 @@ extension XcodeList {
 }
 
 extension XcodeList {
+    // MARK: - Apple
+
     private func releasedXcodes() -> Promise<[Xcode]> {
         return firstly { () -> Promise<(data: Data, response: URLResponse)> in
             Current.network.dataTask(with: URLRequest.downloads)
@@ -100,4 +113,63 @@ extension XcodeList {
 
         return [Xcode(version: version, url: url, filename: filename, releaseDate: DateFormatter.downloadsReleaseDate.date(from: releaseDateString))]
     }
+}
+
+extension XcodeList {
+    // MARK: - XcodeReleases
+    
+    private func xcodeReleases() -> Promise<[Xcode]> {
+        return firstly { () -> Promise<(data: Data, response: URLResponse)> in
+            Current.network.dataTask(with: URLRequest(url: URL(string: "https://xcodereleases.com/data.json")!))
+        }
+        .map { (data, response) in
+            let decoder = JSONDecoder()
+            let xcReleasesXcodes = try decoder.decode([XCModel.Xcode].self, from: data)
+            let xcodes = xcReleasesXcodes.compactMap { xcReleasesXcode -> Xcode? in
+                guard
+                    let downloadURL = xcReleasesXcode.links?.download?.url,
+                    let version = Version(xcReleasesXcode: xcReleasesXcode)
+                else { return nil }
+                
+                let releaseDate = Calendar(identifier: .gregorian).date(from: DateComponents(
+                    year: xcReleasesXcode.date.year,
+                    month: xcReleasesXcode.date.month,
+                    day: xcReleasesXcode.date.day
+                ))
+                
+                return Xcode(
+                    version: version,
+                    url: downloadURL,
+                    filename: String(downloadURL.path.suffix(fromLast: "/")),
+                    releaseDate: releaseDate
+                )
+            }
+            return xcodes
+        }
+        .map(filterPrereleasesThatMatchReleaseBuildMetadataIdentifiers)
+    }
+    
+    /// Xcode Releases may have multiple releases with the same build metadata when a build doesn't change between candidate and final releases.
+    /// For example, 12.3 RC and 12.3 are both build 12C33
+    /// We don't care about that difference, so only keep the final release (GM or Release, in XCModel terms).
+    /// The downside of this is that a user could technically have both releases installed, and so they won't both be shown in the list, but I think most users wouldn't do this.
+    func filterPrereleasesThatMatchReleaseBuildMetadataIdentifiers(_ xcodes: [Xcode]) -> [Xcode] {
+        var filteredXcodes: [Xcode] = []
+        for xcode in xcodes {
+            if xcode.version.buildMetadataIdentifiers.isEmpty {
+                filteredXcodes.append(xcode)
+                continue
+            }
+            
+            let xcodesWithSameBuildMetadataIdentifiers = xcodes
+                .filter({ $0.version.buildMetadataIdentifiers == xcode.version.buildMetadataIdentifiers })
+            if xcodesWithSameBuildMetadataIdentifiers.count > 1,
+               xcode.version.prereleaseIdentifiers.isEmpty || xcode.version.prereleaseIdentifiers == ["GM"] {
+                filteredXcodes.append(xcode)
+            } else if xcodesWithSameBuildMetadataIdentifiers.count == 1 {
+                filteredXcodes.append(xcode)
+            }
+        }
+        return filteredXcodes
+    } 
 }

--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -76,7 +76,7 @@ public func chooseFromInstalledXcodesInteractively(currentPath: String, director
     sortedInstalledXcodes
         .enumerated()
         .forEach { index, installedXcode in
-            var output = "\(index + 1)) \(installedXcode.version.xcodeDescription)"
+            var output = "\(index + 1)) \(installedXcode.version.appleDescriptionWithBuildIdentifier)"
             if currentPath.hasPrefix(installedXcode.path.string) {
                 output += " (Selected)"
             }

--- a/Sources/xcodes/DataSource+ExpressibleByArgument.swift
+++ b/Sources/xcodes/DataSource+ExpressibleByArgument.swift
@@ -1,0 +1,4 @@
+import ArgumentParser
+import XcodesKit
+
+extension DataSource: ExpressibleByArgument {}

--- a/Tests/XcodesKitTests/Fixtures/Stub.version.plist
+++ b/Tests/XcodesKitTests/Fixtures/Stub.version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>ProductBuildVersion</key>
-	<string>0.0.0</string>
+	<string>ABC123</string>
 </dict>
 </plist>

--- a/Tests/XcodesKitTests/Models+FirstWithVersionTests.swift
+++ b/Tests/XcodesKitTests/Models+FirstWithVersionTests.swift
@@ -12,9 +12,11 @@ final class ModelsFirstWithVersionTests: XCTestCase {
         Xcode(version: Version(xcodeVersion: "4.5.6 Beta 1")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode4.5.6Beta1.app"), filename: "Xcode4.5.6Beta1app",  releaseDate: nil),
         Xcode(version: Version(xcodeVersion: "4.5.6 Beta 2")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode4.5.6Beta2.app"), filename: "Xcode4.5.6Beta2.app", releaseDate: nil),
         
-        Xcode(version: Version(xcodeVersion: "7.8.9")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9.app"), filename: "Xcode7.8.9.app", releaseDate: nil),
+        Xcode(version: Version("7.8.9-GM+ABC123")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9GM.app"), filename: "Xcode7.8.9GM.app", releaseDate: nil),
+        Xcode(version: Version("7.8.9+ABC123")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9.app"), filename: "Xcode7.8.9.app", releaseDate: nil),
         
         Xcode(version: Version(xcodeVersion: "10.11.12 Release Candidate")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode10.11.12ReleaseCandidate.app"), filename: "Xcode10.11.12ReleaseCandidate.app", releaseDate: nil),
+        Xcode(version: Version(11, 12, 13, prereleaseIdentifiers: ["Release", "Candidate"], buildMetadataIdentifiers: ["DEF456"]), url: URL(fileURLWithPath: "https://developer.apple.com/Xcode11.12.13ReleaseCandidate.app"), filename: "Xcode11.12.13ReleaseCandidate.app", releaseDate: nil),
     ]
     
     let installedXcodes = [
@@ -25,9 +27,11 @@ final class ModelsFirstWithVersionTests: XCTestCase {
         InstalledXcode(path: Path("/Applications/Xcode-4.5.6-beta.1.app")!, version: Version(xcodeVersion: "4.5.6 Beta 1")!),
         InstalledXcode(path: Path("/Applications/Xcode-4.5.6-beta.2.app")!, version: Version(xcodeVersion: "4.5.6 Beta 2")!),
         
-        InstalledXcode(path: Path("/Applications/Xcode-7.8.9.app")!, version: Version(xcodeVersion: "7.8.9")!),
+        InstalledXcode(path: Path("/Applications/Xcode-7.8.9-gm.app")!, version: Version("7.8.9-GM+ABC123")!),
+        InstalledXcode(path: Path("/Applications/Xcode-7.8.9.app")!, version: Version("7.8.9+ABC123")!),
         
         InstalledXcode(path: Path("/Applications/Xcode-10.11.12-release.candidate.app")!, version: Version(xcodeVersion: "10.11.12 Release Candidate")!),
+        InstalledXcode(path: Path("/Applications/Xcode-11.12.13-release.candidate.app")!, version: Version(11, 12, 13, prereleaseIdentifiers: ["Release", "Candidate"], buildMetadataIdentifiers: ["DEF456"])),
     ]
     
     func test_xcodes_exactMatch() {
@@ -39,9 +43,15 @@ final class ModelsFirstWithVersionTests: XCTestCase {
             xcodes.first(withVersion: Version(xcodeVersion: "1.2.3 Beta 2")!),
             Xcode(version: Version(xcodeVersion: "1.2.3 Beta 2")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode1.2.3Beta2.app"), filename: "Xcode1.2.3Beta2.app", releaseDate: nil)
         )
+        
+        // With build metadata
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "7.8.9 gm")!),
+            Xcode(version: Version("7.8.9-GM+ABC123")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9GM.app"), filename: "Xcode7.8.9GM.app", releaseDate: nil)
+        )
         XCTAssertEqual(
             xcodes.first(withVersion: Version(xcodeVersion: "7.8.9")!),
-            Xcode(version: Version(xcodeVersion: "7.8.9")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9.app"), filename: "Xcode7.8.9.app", releaseDate: nil)
+            Xcode(version: Version("7.8.9+ABC123")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode7.8.9.app"), filename: "Xcode7.8.9.app", releaseDate: nil)
         )
     }
     
@@ -49,6 +59,12 @@ final class ModelsFirstWithVersionTests: XCTestCase {
         XCTAssertEqual(
             xcodes.first(withVersion: Version(xcodeVersion: "10.11.12")!),
             Xcode(version: Version(xcodeVersion: "10.11.12 Release Candidate")!, url: URL(fileURLWithPath: "https://developer.apple.com/Xcode10.11.12ReleaseCandidate.app"), filename: "Xcode10.11.12ReleaseCandidate.app", releaseDate: nil)
+        )
+        
+        // With build metadata
+        XCTAssertEqual(
+            xcodes.first(withVersion: Version(xcodeVersion: "11.12.13")!),
+            Xcode(version: Version(11, 12, 13, prereleaseIdentifiers: ["Release", "Candidate"], buildMetadataIdentifiers: ["DEF456"]), url: URL(fileURLWithPath: "https://developer.apple.com/Xcode11.12.13ReleaseCandidate.app"), filename: "Xcode11.12.13ReleaseCandidate.app", releaseDate: nil)
         )
     }
     
@@ -75,9 +91,15 @@ final class ModelsFirstWithVersionTests: XCTestCase {
             installedXcodes.first(withVersion: Version(xcodeVersion: "1.2.3 Beta 2")!),
             InstalledXcode(path: Path("/Applications/Xcode-1.2.3-beta.2.app")!, version: Version(xcodeVersion: "1.2.3 Beta 2")!)
         )
+        
+        // With build metadata
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "7.8.9 gm")!),
+            InstalledXcode(path: Path("/Applications/Xcode-7.8.9-gm.app")!, version: Version("7.8.9-GM+ABC123")!)
+        )
         XCTAssertEqual(
             installedXcodes.first(withVersion: Version(xcodeVersion: "7.8.9")!),
-            InstalledXcode(path: Path("/Applications/Xcode-7.8.9.app")!, version: Version(xcodeVersion: "7.8.9")!)
+            InstalledXcode(path: Path("/Applications/Xcode-7.8.9.app")!, version: Version("7.8.9+ABC123")!)
         )
     }
     
@@ -85,6 +107,12 @@ final class ModelsFirstWithVersionTests: XCTestCase {
         XCTAssertEqual(
             installedXcodes.first(withVersion: Version(xcodeVersion: "10.11.12")!),
             InstalledXcode(path: Path("/Applications/Xcode-10.11.12-release.candidate.app")!, version: Version(xcodeVersion: "10.11.12 Release Candidate")!)
+        )
+        
+        // With build metadata
+        XCTAssertEqual(
+            installedXcodes.first(withVersion: Version(xcodeVersion: "11.12.13")!),
+            InstalledXcode(path: Path("/Applications/Xcode-11.12.13-release.candidate.app")!, version: Version(11, 12, 13, prereleaseIdentifiers: ["Release", "Candidate"], buildMetadataIdentifiers: ["DEF456"]))
         )
     }
     
@@ -100,5 +128,14 @@ final class ModelsFirstWithVersionTests: XCTestCase {
             installedXcodes.first(withVersion: Version(xcodeVersion: "4.5.6")!),
             nil
         )
+    }
+    
+    func test_XcodeVersionEqualWithoutAllIdentifiers() {
+        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12")!))
+        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0")!))
+        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0.0")!))
+        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12")!))
+        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0")!))
+        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0.0")!))
     }
 }

--- a/Tests/XcodesKitTests/Version+XcodeTests.swift
+++ b/Tests/XcodesKitTests/Version+XcodeTests.swift
@@ -29,17 +29,8 @@ class VersionXcodeTests: XCTestCase {
     }
 
     func test_Equivalence() {
-        XCTAssertTrue(Version("10.2.1")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1+abcdef")!))
-        XCTAssertFalse(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1-beta+abcdef")!))
-        XCTAssertTrue(Version("10.2.1-beta+qwerty")!.isEquivalentForDeterminingIfInstalled(toInstalled: Version("10.2.1-beta+QWERTY")!))
-    }
-
-    func test_XcodeVersionEquivalence() {
-        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12")!))
-        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0")!))
-        XCTAssertTrue(Version("12.0.0-beta")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0.0")!))
-        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12")!))
-        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0")!))
-        XCTAssertTrue(Version("12.0.0-beta+qwerty")!.isEqualWithoutAllIdentifiers(to: Version(xcodeVersion: "12.0.0")!))
+        XCTAssertTrue(Version("10.2.1")!.isEquivalent(to: Version("10.2.1+abcdef")!))
+        XCTAssertFalse(Version("10.2.1-beta+qwerty")!.isEquivalent(to: Version("10.2.1-beta+abcdef")!))
+        XCTAssertTrue(Version("10.2.1-beta+qwerty")!.isEquivalent(to: Version("10.2.1-beta+QWERTY")!))
     }
 }

--- a/Tests/XcodesKitTests/Version+XcodeTests.swift
+++ b/Tests/XcodesKitTests/Version+XcodeTests.swift
@@ -18,14 +18,14 @@ class VersionXcodeTests: XCTestCase {
         XCTAssertEqual(Version(xcodeVersion: "Xcode 10.2 GM seed 2"), Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed", "2"]))
     }
 
-    func test_XcodeDescription() {
-        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0).xcodeDescription,                                          "10.2")
-        XCTAssertEqual(Version(major: 10, minor: 2, patch: 1).xcodeDescription,                                          "10.2.1")
-        XCTAssertEqual(Version(major: 11, minor: 0, patch: 0, prereleaseIdentifiers: ["beta"]).xcodeDescription,         "11.0 Beta")
-        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["beta", "4"]).xcodeDescription,    "10.2 Beta 4")
-        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm"]).xcodeDescription,           "10.2 GM")
-        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed"]).xcodeDescription,      "10.2 GM Seed")
-        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed", "1"]).xcodeDescription, "10.2 GM Seed 1")
+    func test_AppleDescription() {
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0).appleDescription,                                          "10.2")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 1).appleDescription,                                          "10.2.1")
+        XCTAssertEqual(Version(major: 11, minor: 0, patch: 0, prereleaseIdentifiers: ["beta"]).appleDescription,         "11.0 Beta")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["beta", "4"]).appleDescription,    "10.2 Beta 4")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm"]).appleDescription,           "10.2 GM")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed"]).appleDescription,      "10.2 GM Seed")
+        XCTAssertEqual(Version(major: 10, minor: 2, patch: 0, prereleaseIdentifiers: ["gm-seed", "1"]).appleDescription, "10.2 GM Seed 1")
     }
 
     func test_Equivalence() {

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -197,7 +197,7 @@ final class XcodesKitTests: XCTestCase {
 
         let expectation = self.expectation(description: "Finished")
 
-        installer.install(.version("0.0.0"), downloader: .urlSession, destination: Path.root.join("Applications"))
+        installer.install(.version("0.0.0"), dataSource: .apple, downloader: .urlSession, destination: Path.root.join("Applications"))
             .ensure {
                 let url = Bundle.module.url(forResource: "LogOutput-FullHappyPath", withExtension: "txt", subdirectory: "Fixtures")!
                 XCTAssertEqual(log, try! String(contentsOf: url))
@@ -290,7 +290,7 @@ final class XcodesKitTests: XCTestCase {
 
         let expectation = self.expectation(description: "Finished")
 
-        installer.install(.version("0.0.0"), downloader: .urlSession, destination: Path.home.join("Xcode"))
+        installer.install(.version("0.0.0"), dataSource: .apple, downloader: .urlSession, destination: Path.home.join("Xcode"))
             .ensure {
                 let url = Bundle.module.url(forResource: "LogOutput-AlternativeDirectory", withExtension: "txt", subdirectory: "Fixtures")!
                 let expectedText = try! String(contentsOf: url).replacingOccurrences(of: "/Users/brandon", with: Path.home.string)
@@ -404,7 +404,7 @@ final class XcodesKitTests: XCTestCase {
 
         let expectation = self.expectation(description: "Finished")
 
-        installer.install(.version("0.0.0"), downloader: .urlSession, destination: Path.root.join("Applications"))
+        installer.install(.version("0.0.0"), dataSource: .apple, downloader: .urlSession, destination: Path.root.join("Applications"))
             .ensure {
                 let url = Bundle.module.url(forResource: "LogOutput-IncorrectSavedPassword", withExtension: "txt", subdirectory: "Fixtures")!
                 XCTAssertEqual(log, try! String(contentsOf: url))
@@ -522,7 +522,7 @@ final class XcodesKitTests: XCTestCase {
 
         let expectation = self.expectation(description: "Finished")
 
-        installer.install(.version("0.0.0"), downloader: .urlSession, destination: Path.root.join("Applications"))
+        installer.install(.version("0.0.0"), dataSource: .apple, downloader: .urlSession, destination: Path.root.join("Applications"))
             .ensure {
                 let url = Bundle.module.url(forResource: "LogOutput-DamagedXIP", withExtension: "txt", subdirectory: "Fixtures")!
                 let expectedText = try! String(contentsOf: url).replacingOccurrences(of: "/Users/brandon", with: Path.home.string)

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -897,8 +897,8 @@ final class XcodesKitTests: XCTestCase {
 
         XCTAssertEqual(log, """
         Available Xcode versions:
-        1) 0.0
-        2) 2.0.1 (Selected)
+        1) 0.0 (ABC123)
+        2) 2.0.1 (ABC123) (Selected)
         Enter the number of the Xcode to select: 
         xcodes requires superuser privileges to select an Xcode
         macOS User Password: 


### PR DESCRIPTION
This adds support for [Xcode Releases](https://xcodereleases.com) as a data source for available Xcode versions, and makes it the default. It's still possible to use the Apple data source by providing the `--data-source=apple` option. The motivation for this is that while the data is unofficial it is more complete and reliable than scraping the Apple Developer website. This code is all taken from (with some small changes) [Xcodes.app](https://github.com/RobotsAndPencils/XcodesApp).

Two other changes come along with this:

- Previously build identifiers (for example "12C33" for the final 12.3 release) were only shown for non-final release versions. I think there's value in showing this for all versions since sometimes you need to figure out exactly what versions are installed or available, for example when Apple releases a final version that was the same build as a release candidate. This is now done when versions are printed in a list (list, installed, select).
- Version comparison has been simplified in most cases. It's still a little fuzzy when parsing version strings from the user, which is expected.

## Testing

`swift run xcodes update` first to make sure you have Xcode Releases data, and then use other commands and make sure they still work the way you expect.

You can do the same after running `swift run xcodes update --data-source=apple` to make sure the Apple one still works, except for the issue noted in #123.

---

I'm going to say that this fixes #123 for now. We could invest more time into making the Apple data source work perfectly but part of the motivation for adding Xcode Releases support is to not have to do that. If another contributor wishes to do so we'd welcome that change.