### PR TITLE
Add support for coloured output

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -56,6 +56,15 @@
         }
       },
       {
+        "package": "Rainbow",
+        "repositoryURL": "https://github.com/onevcat/Rainbow.git",
+        "state": {
+          "branch": null,
+          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+          "version": "3.2.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         .package(url: "https://github.com/mxcl/LegibleError.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.2.0")),
         .package(name: "XcodeReleases", url: "https://github.com/xcodereleases/data", .revision("b47228c688b608e34b3b84079ab6052a24c7a981")),
+        .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMinor(from: "3.2.0")),
     ],
     targets: [
         .target(
@@ -46,6 +47,7 @@ let package = Package(
                 "SwiftSoup",
                 "Version", 
                 .product(name: "XCModel", package: "XcodeReleases"),
+                "Rainbow",
             ]),
         .testTarget(
             name: "XcodesKitTests",
@@ -60,7 +62,8 @@ let package = Package(
             name: "AppleAPI",
             dependencies: [
                 "PromiseKit",
-                "PMKFoundation"
+                "PMKFoundation",
+                "Rainbow",
             ]),
         .testTarget(
             name: "AppleAPITests",

--- a/Sources/AppleAPI/Client.swift
+++ b/Sources/AppleAPI/Client.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PromiseKit
 import PMKFoundation
+import Rainbow
 
 public class Client {
     private static let authTypes = ["sa", "hsa", "non-sa", "hsa2"]
@@ -105,12 +106,12 @@ public class Client {
         .then { authOptions -> Promise<Void> in
             switch authOptions.kind {
             case .twoStep:
-                Current.logging.log("Received a response from Apple that indicates this account has two-step authentication enabled. xcodes currently only supports the newer two-factor authentication, though. Please consider upgrading to two-factor authentication, or open an issue on GitHub explaining why this isn't an option for you here: https://github.com/RobotsAndPencils/xcodes/issues/new")
+                Current.logging.log("Received a response from Apple that indicates this account has two-step authentication enabled. xcodes currently only supports the newer two-factor authentication, though. Please consider upgrading to two-factor authentication, or open an issue on GitHub explaining why this isn't an option for you here: https://github.com/RobotsAndPencils/xcodes/issues/new".yellow)
                 return Promise.value(())
             case .twoFactor:
                 return self.handleTwoFactor(serviceKey: serviceKey, sessionID: sessionID, scnt: scnt, authOptions: authOptions)
             case .unknown:
-                Current.logging.log("Received a response from Apple that indicates this account has two-step or two-factor authentication enabled, but xcodes is unsure how to handle this response:")
+                Current.logging.log("Received a response from Apple that indicates this account has two-step or two-factor authentication enabled, but xcodes is unsure how to handle this response:".red)
                 String(data: data, encoding: .utf8).map { Current.logging.log($0) }
                 return Promise.value(())
             }
@@ -182,7 +183,7 @@ public class Client {
         }
         .recover { error throws -> Promise<AuthOptionsResponse.TrustedPhoneNumber> in
             guard case Error.invalidPhoneNumberIndex = error else { throw error }
-            Current.logging.log("\(error.localizedDescription)\n")
+            Current.logging.log("\(error.localizedDescription)\n".red)
             return self.selectPhoneNumberInteractively(from: trustedPhoneNumbers)
         }
     }

--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -2,6 +2,7 @@ import Foundation
 import PromiseKit
 import Path
 import Version
+import Rainbow
 
 public func selectXcode(shouldPrint: Bool, pathOrVersion: String, directory: Path) -> Promise<Void> {
     firstly { () -> Promise<ProcessOutput> in
@@ -25,20 +26,20 @@ public func selectXcode(shouldPrint: Bool, pathOrVersion: String, directory: Pat
            let installedXcode = Current.files.installedXcodes(directory).first(withVersion: version) {
             return selectXcodeAtPath(installedXcode.path.string)
                 .done { output in
-                    Current.logging.log("Selected \(output.out)")
+                    Current.logging.log("Selected \(output.out)".green)
                     Current.shell.exit(0)
                 }
         }
         else {
             return selectXcodeAtPath(pathOrVersion)
                 .done { output in
-                    Current.logging.log("Selected \(output.out)")
+                    Current.logging.log("Selected \(output.out)".green)
                     Current.shell.exit(0)
                 }
                 .recover { _ in
                     selectXcodeInteractively(currentPath: output.out, directory: directory)
                         .done { output in
-                            Current.logging.log("Selected \(output.out)")
+                            Current.logging.log("Selected \(output.out)".green)
                             Current.shell.exit(0)
                         }
                 }
@@ -54,7 +55,7 @@ public func selectXcodeInteractively(currentPath: String, directory: Path, shoul
             }
             .recover { error throws -> Promise<ProcessOutput> in
                 guard case XcodeSelectError.invalidIndex = error else { throw error }
-                Current.logging.log("\(error.legibleLocalizedDescription)\n")
+                Current.logging.log("\(error.legibleLocalizedDescription)\n".red)
                 return selectWithRetry(currentPath: currentPath)
             }
         }
@@ -78,7 +79,7 @@ public func chooseFromInstalledXcodesInteractively(currentPath: String, director
         .forEach { index, installedXcode in
             var output = "\(index + 1)) \(installedXcode.version.appleDescriptionWithBuildIdentifier)"
             if currentPath.hasPrefix(installedXcode.path.string) {
-                output += " (Selected)"
+                output += " (\("Selected".green))"
             }
             Current.logging.log(output)
         }

--- a/Sources/xcodes/ParsableArguments+LegibleError.swift
+++ b/Sources/xcodes/ParsableArguments+LegibleError.swift
@@ -1,10 +1,11 @@
 import ArgumentParser
 import LegibleError
 import XcodesKit
+import Rainbow
 
 extension ParsableArguments {
     static func exit(withLegibleError error: Error) -> Never {
-        Current.logging.log(error.legibleLocalizedDescription)
+        Current.logging.log(error.legibleLocalizedDescription.red)
         Self.exit(withError: ExitCode.failure)
     }
 }

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -5,13 +5,14 @@ import PromiseKit
 import XcodesKit
 import LegibleError
 import Path
+import Rainbow
 
 func getDirectory(possibleDirectory: String?, default: Path = Path.root.join("Applications")) -> Path {
     let directory = possibleDirectory.flatMap(Path.init) ??
         ProcessInfo.processInfo.environment["XCODES_DIRECTORY"].flatMap(Path.init) ?? 
         `default`
     guard directory.isDirectory else {
-        Current.logging.log("Directory argument must be a directory, but was provided \(directory.string).")
+        Current.logging.log("Directory argument must be a directory, but was provided \(directory.string).".red)
         exit(1)
     }
     return directory
@@ -35,6 +36,19 @@ struct GlobalDataSourceOption: ParsableArguments {
         )
     )
     var dataSource: DataSource = .xcodeReleases
+}
+
+struct GlobalColorOption: ParsableArguments {
+    @Flag(
+        inversion: .prefixedNo,
+        help: ArgumentHelp(
+            "Determines whether output should be colored.",
+            discussion: """
+                xcodes will also disable colored output if its not running in an interactive terminal, if the NO_COLOR environment variable is set, or if the TERM environment variable is set to "dumb". 
+                """
+        )
+    )
+    var color: Bool = true
 }
 
 struct Xcodes: ParsableCommand {
@@ -94,8 +108,13 @@ struct Xcodes: ParsableCommand {
         
         @OptionGroup
         var globalDataSource: GlobalDataSourceOption
+
+        @OptionGroup
+        var globalColor: GlobalColorOption
         
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             let versionString = version.joined(separator: " ")
             
             let installation: XcodeInstaller.InstallationType
@@ -124,9 +143,9 @@ struct Xcodes: ParsableCommand {
                         Current.logging.log("""
                             Failed executing: `\(process)` (\(process.terminationStatus))
                             \([standardOutput, standardError].compactMap { $0 }.joined(separator: "\n"))
-                            """)
+                            """.red)
                     default:
-                        Current.logging.log(error.legibleLocalizedDescription)
+                        Current.logging.log(error.legibleLocalizedDescription.red)
                     }
                     
                     Install.exit(withError: ExitCode.failure)
@@ -180,8 +199,13 @@ struct Xcodes: ParsableCommand {
         
         @OptionGroup
         var globalDataSource: GlobalDataSourceOption
+
+        @OptionGroup
+        var globalColor: GlobalColorOption
         
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             let versionString = version.joined(separator: " ")
             
             let installation: XcodeInstaller.InstallationType
@@ -212,9 +236,9 @@ struct Xcodes: ParsableCommand {
                         Current.logging.log("""
                             Failed executing: `\(process)` (\(process.terminationStatus))
                             \([standardOutput, standardError].compactMap { $0 }.joined(separator: "\n"))
-                            """)
+                            """.red)
                     default:
-                        Current.logging.log(error.legibleLocalizedDescription)
+                        Current.logging.log(error.legibleLocalizedDescription.red)
                     }
                     
                     Install.exit(withError: ExitCode.failure)
@@ -232,7 +256,12 @@ struct Xcodes: ParsableCommand {
         @OptionGroup
         var globalDirectory: GlobalDirectoryOption
         
+        @OptionGroup
+        var globalColor: GlobalColorOption
+        
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             let directory = getDirectory(possibleDirectory: globalDirectory.directory)
             
             installer.printInstalledXcodes(directory: directory)
@@ -253,8 +282,13 @@ struct Xcodes: ParsableCommand {
         
         @OptionGroup
         var globalDataSource: GlobalDataSourceOption
+
+        @OptionGroup
+        var globalColor: GlobalColorOption
         
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             let directory = getDirectory(possibleDirectory: globalDirectory.directory)
             
             firstly { () -> Promise<Void> in
@@ -296,7 +330,12 @@ struct Xcodes: ParsableCommand {
         @OptionGroup
         var globalDirectory: GlobalDirectoryOption
         
+        @OptionGroup
+        var globalColor: GlobalColorOption
+        
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             let directory = getDirectory(possibleDirectory: globalDirectory.directory)
             
             selectXcode(shouldPrint: print, pathOrVersion: versionOrPath.joined(separator: " "), directory: directory)
@@ -326,7 +365,12 @@ struct Xcodes: ParsableCommand {
         @OptionGroup
         var globalDirectory: GlobalDirectoryOption
         
+        @OptionGroup
+        var globalColor: GlobalColorOption
+        
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             let directory = getDirectory(possibleDirectory: globalDirectory.directory)
 
             installer.uninstallXcode(version.joined(separator: " "), directory: directory)
@@ -347,8 +391,13 @@ struct Xcodes: ParsableCommand {
         
         @OptionGroup
         var globalDataSource: GlobalDataSourceOption
+
+        @OptionGroup
+        var globalColor: GlobalColorOption
         
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             let directory = getDirectory(possibleDirectory: globalDirectory.directory)
             
             installer.updateAndPrint(dataSource: globalDataSource.dataSource, directory: directory)
@@ -364,7 +413,12 @@ struct Xcodes: ParsableCommand {
             abstract: "Print the version number of xcodes itself"
         )
         
+        @OptionGroup
+        var globalColor: GlobalColorOption
+        
         func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+
             Current.logging.log(XcodesKit.version.description)
         }
     }

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NoColor.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NoColor.txt
@@ -108,5 +108,5 @@ Apple ID Password:
 (6/6) Finishing installation
 xcodes requires superuser privileges in order to finish installation.
 macOS User Password: 
-[32m
-Xcode 0.0.0 has been installed to /Applications/Xcode-0.0.0.app[0m
+
+Xcode 0.0.0 has been installed to /Applications/Xcode-0.0.0.app

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -4,6 +4,7 @@ import PromiseKit
 import PMKFoundation
 import Path
 import AppleAPI
+import Rainbow
 @testable import XcodesKit
 
 final class XcodesKitTests: XCTestCase {
@@ -17,6 +18,8 @@ final class XcodesKitTests: XCTestCase {
 
     override func setUp() {
         Current = .mock
+        Rainbow.outputTarget = .unknown
+        Rainbow.enabled = false
         installer = XcodeInstaller(configuration: Configuration(), xcodeList: XcodeList())
     }
 
@@ -118,6 +121,9 @@ final class XcodesKitTests: XCTestCase {
     }
 
     func test_InstallLogging_FullHappyPath() {
+        Rainbow.outputTarget = .console
+        Rainbow.enabled = true
+
         var log = ""
         XcodesKit.Current.logging.log = { log.append($0 + "\n") }
 
@@ -200,6 +206,99 @@ final class XcodesKitTests: XCTestCase {
         installer.install(.version("0.0.0"), dataSource: .apple, downloader: .urlSession, destination: Path.root.join("Applications"))
             .ensure {
                 let url = Bundle.module.url(forResource: "LogOutput-FullHappyPath", withExtension: "txt", subdirectory: "Fixtures")!
+                XCTAssertEqual(log, try! String(contentsOf: url))
+                expectation.fulfill()
+            }
+            .catch {
+                XCTFail($0.localizedDescription)
+            }
+
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func test_InstallLogging_FullHappyPath_NoColor() {
+        var log = ""
+        XcodesKit.Current.logging.log = { log.append($0 + "\n") }
+
+        // Don't have a valid session
+        Current.network.validateSession = { Promise(error: AppleAPI.Client.Error.invalidSession) }
+        // It hasn't been downloaded
+        Current.files.fileExistsAtPath = { path in
+            if path == (Path.xcodesApplicationSupport/"Xcode-0.0.0.xip").string {
+                return false
+            }
+            else {
+                return true
+            }
+        }
+        // It's an available release version
+        XcodesKit.Current.network.dataTask = { url in
+            if url.pmkRequest.url! == URLRequest.downloads.url! {
+                let downloads = Downloads(downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip")], dateModified: Date())])
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .formatted(.downloadsDateModified)
+                let downloadsData = try! encoder.encode(downloads)
+                return Promise.value((data: downloadsData, response: HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+            }
+
+            return Promise.value((data: Data(), response: HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+        }
+        // It downloads and updates progress
+        Current.network.downloadTask = { (url, saveLocation, _) -> (Progress, Promise<(saveLocation: URL, response: URLResponse)>) in
+            let progress = Progress(totalUnitCount: 100)
+            return (progress,
+                    Promise { resolver in
+                        // Need this to run after the Promise has returned to the caller. This makes the test async, requiring waiting for an expectation.
+                        DispatchQueue.main.async {
+                            for i in 0...100 {
+                                progress.completedUnitCount = Int64(i)
+                            }
+                            resolver.fulfill((saveLocation: saveLocation,
+                                              response: HTTPURLResponse(url: url.pmkRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+                        }
+                    })
+        }
+        // It's a valid .app
+        Current.shell.codesignVerify = { _ in
+            return Promise.value(
+                ProcessOutput(
+                    status: 0,
+                    out: "",
+                    err: """
+                        TeamIdentifier=\(XcodeInstaller.XcodeTeamIdentifier)
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[0])
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[1])
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[2])
+                        """))
+        }
+        // Don't have superuser privileges the first time
+        var validateSudoAuthenticationCallCount = 0
+        XcodesKit.Current.shell.validateSudoAuthentication = {
+            validateSudoAuthenticationCallCount += 1
+
+            if validateSudoAuthenticationCallCount == 1 {
+                return Promise(error: Process.PMKError.execution(process: Process(), standardOutput: nil, standardError: nil))
+            }
+            else {
+                return Promise.value(Shell.processOutputMock)
+            }
+        }
+        // User enters password
+        XcodesKit.Current.shell.readSecureLine = { prompt, _ in
+            XcodesKit.Current.logging.log(prompt)
+            return "password"
+        }
+        // User enters something
+        XcodesKit.Current.shell.readLine = { prompt in
+            XcodesKit.Current.logging.log(prompt)
+            return "asdf"
+        }
+
+        let expectation = self.expectation(description: "Finished")
+
+        installer.install(.version("0.0.0"), dataSource: .apple, downloader: .urlSession, destination: Path.root.join("Applications"))
+            .ensure {
+                let url = Bundle.module.url(forResource: "LogOutput-FullHappyPath-NoColor", withExtension: "txt", subdirectory: "Fixtures")!
                 XCTAssertEqual(log, try! String(contentsOf: url))
                 expectation.fulfill()
             }


### PR DESCRIPTION
This adds Rainbow as a dependency for coloured output.

I find this helps in two situations:

- When looking at a long list of information, like output from `xcodes list`, it's easier to visually scan for lines that are coloured in some way. In this specific case, Installed is printed in blue and Selected is printed in green.
- Warnings, errors and success during long-running processes, like downloading and installing, are easier to identify at a glance when it's coloured yellow, red, or green, respectively.

|list|installed|select|error|no color|
|-----|-----|-----|-----|-----|
| <img width="306" alt="Screen Shot 2021-02-02 at 7 31 18 PM" src="https://user-images.githubusercontent.com/594059/106689592-7a34b200-658d-11eb-9ec4-261804c3f353.png"> | <img width="656" alt="Screen Shot 2021-02-02 at 7 31 35 PM" src="https://user-images.githubusercontent.com/594059/106689612-80c32980-658d-11eb-911b-42be796644b5.png"> | <img width="544" alt="Screen Shot 2021-02-02 at 7 32 09 PM" src="https://user-images.githubusercontent.com/594059/106689627-86b90a80-658d-11eb-99ed-649bf12e2944.png"> | <img width="528" alt="Screen Shot 2021-02-02 at 7 32 25 PM" src="https://user-images.githubusercontent.com/594059/106689634-8ae52800-658d-11eb-80d7-ce5b52be5524.png"> | <img width="682" alt="Screen Shot 2021-02-02 at 7 35 19 PM" src="https://user-images.githubusercontent.com/594059/106689785-d13a8700-658d-11eb-93b7-bc2e12cbbeda.png"> |


I've added a global `--color/no-color` flag that defaults to true/enabled. If xcodes is running in an interactive terminal then it will use color by default. It will disable coloured output if the user provides the `--no-color` flag, if its not running in an interactive terminal, if the NO_COLOR environment variable is set, or if the TERM environment variable is set to "dumb". This is following the suggestions in [Command Line Interface Guidelines](https://clig.dev/#output)

---

One thing that would be good to do next is expand on Logging.log with different logging levels, like info, debug, warn and error. That would enable two things:

- A global verbose flag to enable debug-level logs for debugging and testing purposes
- Colors could be set for the warn and error levels in one place, instead of at the call site. We could also send errors to STDERR, which would be more appropriate.