### PR TITLE
Uninstall Interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Xcode will be installed to /Applications by default, but you can provide the pat
 - `installed`: List the versions of Xcode that are installed
 - `list`: List all versions of Xcode that are available to install
 - `select`: Change the selected Xcode
-- `uninstall <version>`: Uninstall a specific version of Xcode
+- `uninstall`: Uninstall a specific version of Xcode
 - `update`: Update the list of available versions of Xcode
 - `version`: Print the version number of xcodes itself
 

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -283,16 +283,19 @@ struct Xcodes: ParsableCommand {
             RunLoop.current.run()
         }
     }
-    
+        
     struct Uninstall: ParsableCommand {
         static var configuration = CommandConfiguration(
-            abstract: "Uninstall a specific version of Xcode",
+            abstract: "Uninstall a version of Xcode",
             discussion: """
+                        Run without any arguments to interactively select from a list.
+
                         EXAMPLES:
-                          xcodes uninstall 10.2.1
+                          xcodes uninstall
+                          xcodes uninstall 11.4.0
                         """
         )
-
+        
         @Argument(help: "The version to uninstall",
                   completion: .custom { _ in Current.files.installedXcodes(getDirectory(possibleDirectory: nil)).sorted { $0.version < $1.version }.map { $0.version.xcodeDescription } })
         var version: [String] = []

--- a/Tests/XcodesKitTests/XcodesKitTests.swift
+++ b/Tests/XcodesKitTests/XcodesKitTests.swift
@@ -639,7 +639,7 @@ final class XcodesKitTests: XCTestCase {
         1) 0.0
         2) 2.0.1
         Enter the number of the Xcode to select: 
-        Xcode 0.0 moved to Trash: \(try Current.files.trashItem(XCTUnwrap(trashedItemAtURL)).path)
+        Xcode 0.0 moved to Trash: \(NSHomeDirectory())/.Trash/Xcode-0.0.0.app
 
         """)
     }


### PR DESCRIPTION
This adds the possibility to uninstall a specific Xcode version by running `xcodes uninstall` and then interactively select which version to uninstall.

This reuse the code used to interactively select a specific Xcode version.

Some tests has also been added.