### PR TITLE
Prints Xcode path for installed versions

### DIFF
--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -637,6 +637,7 @@ public final class XcodeInstaller {
                         if pathOutput.out.hasPrefix(installedXcode.path.string) {
                             output += " (Selected)"
                         }
+                        output += "\t\(installedXcode.path.string)"
                         Current.logging.log(output)
                     }
             }


### PR DESCRIPTION
This change addresses #23 by adding the path of installed Xcode versions to the output of the `installed` command. 