### PR TITLE
Align installed command output into columns for interactive terminals

### DIFF
--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -190,6 +190,8 @@ public struct Shell {
     }
 
     public var exit: (Int32) -> Void = { Darwin.exit($0) }
+    
+    public var isatty: () -> Bool = { Foundation.isatty(fileno(stdout)) != 0 }
 }
 
 public struct Files {

--- a/Tests/XcodesKitTests/Environment+Mock.swift
+++ b/Tests/XcodesKitTests/Environment+Mock.swift
@@ -34,7 +34,8 @@ extension Shell {
         readLine: { _ in return nil },
         readSecureLine: { _, _ in return nil },
         env: { _ in nil },
-        exit: { _ in }
+        exit: { _ in },
+        isatty: { true }
     )
 }
 


### PR DESCRIPTION
The intent of #23 was to make it possible to get the path of installed Xcodes more easily, which was implemented by #133. I realized after I wrote the description of that issue that it should be possible to both make the output nice for humans and also make it easy to pipe to other commands to get the paths for scripting purposes. This PR makes that change.

If standard output is an interactive terminal, which is what you'll see most of the time as a user, space will be added between the two columns so that it's easy to read. If standard output is not an interactive terminal, like when you pipe the output to another command or a file, then no spaces will be added and the current behaviour of adding a tab character will be used.

The expected behaviour is below, which you can try out to verify.

When printing to an interactive terminal:
```
❯ swift run xcodes installed
10.1                           /Applications/Xcode-10.1.app
10.2.1                         /Applications/Xcode-10.2.1.app
11.0                           /Applications/Xcode-11.0.0.app
11.2                           /Applications/Xcode-11.2.0.app
11.2.1                         /Applications/Xcode-11.2.1.app
11.3                           /Applications/Xcode-11.3.0.app
11.4                           /Applications/Xcode-11.4.0.app
11.4.1                         /Applications/Xcode-11.4.1.app
11.5                           /Applications/Xcode-11.5.0.app
11.6                           /Applications/Xcode-11.6.0.app
11.7                           /Applications/Xcode-11.7.0.app
12.0.1                         /Applications/Xcode-12.0.1.app
12.2 Beta (12B5018i)           /Applications/Xcode-12.2.0-Beta.app
12.2                           /Applications/Xcode-12.2.0.app
12.3 Beta (12C5020f)           /Applications/Xcode-12.3.0-Beta.app
12.3 (Selected)                /Applications/Xcode-12.3.0.app
12.4 Release Candidate (12D4e) /Applications/Xcode-12.4.0-Release.Candidate.app
```

When not printing to an interactive terminal:
```
❯ swift run xcodes installed > test; cat test
10.1	/Applications/Xcode-10.1.app
10.2.1	/Applications/Xcode-10.2.1.app
11.0	/Applications/Xcode-11.0.0.app
11.2	/Applications/Xcode-11.2.0.app
11.2.1	/Applications/Xcode-11.2.1.app
11.3	/Applications/Xcode-11.3.0.app
11.4	/Applications/Xcode-11.4.0.app
11.4.1	/Applications/Xcode-11.4.1.app
11.5	/Applications/Xcode-11.5.0.app
11.6	/Applications/Xcode-11.6.0.app
11.7	/Applications/Xcode-11.7.0.app
12.0.1	/Applications/Xcode-12.0.1.app
12.2 Beta (12B5018i)	/Applications/Xcode-12.2.0-Beta.app
12.2	/Applications/Xcode-12.2.0.app
12.3 Beta (12C5020f)	/Applications/Xcode-12.3.0-Beta.app
12.3 (Selected)	/Applications/Xcode-12.3.0.app
12.4 Release Candidate (12D4e)	/Applications/Xcode-12.4.0-Release.Candidate.app
```