### PR TITLE
Don't output download progress when in a non-interactive terminal

### DIFF
--- a/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NonInteractiveTerminal.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NonInteractiveTerminal.txt
@@ -1,0 +1,12 @@
+Apple ID: 
+Apple ID Password: 
+(1/6) Downloading Xcode 0.0.0
+(2/6) Unarchiving Xcode (This can take a while)
+(3/6) Moving Xcode to /Applications/Xcode-0.0.0.app
+(4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
+(5/6) Checking security assessment and code signing
+(6/6) Finishing installation
+xcodes requires superuser privileges in order to finish installation.
+macOS User Password: 
+
+Xcode 0.0.0 has been installed to /Applications/Xcode-0.0.0.app


### PR DESCRIPTION
This change disables download progress output if `xcodes` isn't running in an interactive terminal. In an interactive terminal `xcodes` will update the same line with progress from 0-100%. In a non-interactive terminal `xcodes` used to write 100 separate lines with the ANSI escape codes, and now it'll only print `(1/6) Downloading Xcode X.Y.Z` once.

This is not the only change that should be made for better support of non-interactive terminals (for example #128, or any other use of readline), but it's a start.