### PR TITLE
Add signout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Xcode will be installed to /Applications by default, but you can provide the pat
 - `uninstall`: Uninstall a specific version of Xcode
 - `update`: Update the list of available versions of Xcode
 - `version`: Print the version number of xcodes itself
+- `signout`: Clears the stored username and password
 
 ### Shell Completion Scripts
 

--- a/Sources/AppleAPI/Client.swift
+++ b/Sources/AppleAPI/Client.swift
@@ -29,7 +29,7 @@ public class Client {
             case .noTrustedPhoneNumbers:
                 return "Your account doesn't have any trusted phone numbers, but they're required for two-factor authentication. See https://support.apple.com/en-ca/HT204915."
             case .notAuthenticated:
-                return "No authenticated session found"
+                return "You are already signed out"
             default:
                 return String(describing: self)
             }

--- a/Sources/AppleAPI/Client.swift
+++ b/Sources/AppleAPI/Client.swift
@@ -16,6 +16,7 @@ public class Client {
         case unexpectedSignInResponse(statusCode: Int, message: String?)
         case appleIDAndPrivacyAcknowledgementRequired
         case noTrustedPhoneNumbers
+        case notAuthenticated
 
         public var errorDescription: String? {
             switch self {
@@ -27,6 +28,8 @@ public class Client {
                 return "Not a valid phone number index. Expecting a whole number between \(min)-\(max), but was given \(given ?? "nothing")."
             case .noTrustedPhoneNumbers:
                 return "Your account doesn't have any trusted phone numbers, but they're required for two-factor authentication. See https://support.apple.com/en-ca/HT204915."
+            case .notAuthenticated:
+                return "No authenticated session found"
             default:
                 return String(describing: self)
             }

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -399,6 +399,25 @@ public final class XcodeInstaller {
             }
         }
     }
+    
+    public func logout() -> Promise<Void> {
+        guard let username = findUsername() else { return Promise<Void>(error: Client.Error.notAuthenticated) }
+        
+        return Promise { seal in
+            // Remove cookies in the shared URLSession
+            AppleAPI.Current.network.session.reset {
+                seal.fulfill(())
+            }
+        }
+        .done {
+            // Remove all keychain items
+            try Current.keychain.remove(username)
+
+            // Set `defaultUsername` in Configuration to nil
+            self.configuration.defaultUsername = nil
+            try self.configuration.save()
+        }
+    }
 
     let xcodesUsername = "XCODES_USERNAME"
     let xcodesPassword = "XCODES_PASSWORD"

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -439,7 +439,10 @@ struct Xcodes: ParsableCommand {
                     Current.logging.log("Successfully signed out".green)
                     Signout.exit()
                 }
-                .recover { error in Signout.exit(withLegibleError: error) }
+                .recover { error in
+                    Current.logging.log(error.legibleLocalizedDescription)
+                    Signout.exit()
+                }
             
             RunLoop.current.run()
         }

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -55,7 +55,7 @@ struct Xcodes: ParsableCommand {
     static var configuration = CommandConfiguration(
         abstract: "Manage the Xcodes installed on your Mac",
         shouldDisplay: true,
-        subcommands: [Download.self, Install.self, Installed.self, List.self, Select.self, Uninstall.self, Update.self, Version.self]
+        subcommands: [Download.self, Install.self, Installed.self, List.self, Select.self, Uninstall.self, Update.self, Version.self, Signout.self]
     )
     
     static var xcodesConfiguration = Configuration()
@@ -420,6 +420,28 @@ struct Xcodes: ParsableCommand {
             Rainbow.enabled = Rainbow.enabled && globalColor.color
 
             Current.logging.log(XcodesKit.version.description)
+        }
+    }
+    
+    struct Signout: ParsableCommand {
+        static var configuration = CommandConfiguration(
+            abstract: "Clears the stored username and password"
+        )
+        
+        @OptionGroup
+        var globalColor: GlobalColorOption
+        
+        func run() {
+            Rainbow.enabled = Rainbow.enabled && globalColor.color
+            
+            installer.logout()
+                .done {
+                    Current.logging.log("Successfully signed out".green)
+                    Signout.exit()
+                }
+                .recover { error in Signout.exit(withLegibleError: error) }
+            
+            RunLoop.current.run()
         }
     }
 }


### PR DESCRIPTION
Addresses enhancement #136

## What changed
A new `signout` command has been added to:
* Remove all Keychain items
* Remove cookies in the shared URLSession
* Set `defaultUsername` in Configuration to nil

![xcodes-signout](https://user-images.githubusercontent.com/818102/111414443-a459b380-86a5-11eb-9a04-3af334d460d8.gif)

