### PR TITLE
Forward legible errors

### DIFF
--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -300,7 +300,7 @@ struct Xcodes: ParsableCommand {
                 }
             }
             .done { List.exit() }
-            .catch { error in List.exit(withLegibleError: ExitCode.failure) }
+            .catch { error in List.exit(withLegibleError: error) }
             
             RunLoop.current.run()
         }
@@ -375,7 +375,7 @@ struct Xcodes: ParsableCommand {
 
             installer.uninstallXcode(version.joined(separator: " "), directory: directory)
                 .done { Uninstall.exit() }
-                .catch { error in Uninstall.exit(withLegibleError: ExitCode.failure) }
+                .catch { error in Uninstall.exit(withLegibleError: error) }
             
             RunLoop.current.run()
         }


### PR DESCRIPTION
I'm currently trying to uninstall Xcode 12.5 Beta 3 using `xcodes`, but it fails with the following error:

```bash
$ xcodes uninstall 12.5 Beta 3
The operation couldn’t be completed. (ExitCode(rawValue: 1))
```

Upon investigating the cause, I discovered that the error is not correctly forwarded, which is why I can't see the _real_ error message. This PR fixes that and forwards the catched errors.