### PR TITLE
Fix broken link to `swift-argument-parser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Xcode will be installed to /Applications by default, but you can provide the pat
 
 ### Shell Completion Scripts
 
-xcodes can generate completion scripts which allow you to press the tab key on your keyboard to autocomplete commands and arguments when typing an xcodes command. The steps to install a completion script depend on the shell that you use. More information about installation instructions for different shells and the underlying implementation is available in the [swift-argument-parser repo](https://github.com/apple/swift-argument-parser/blob/master/Documentation/07%20Completion%20Scripts.md).
+xcodes can generate completion scripts which allow you to press the tab key on your keyboard to autocomplete commands and arguments when typing an xcodes command. The steps to install a completion script depend on the shell that you use. More information about installation instructions for different shells and the underlying implementation is available in the [swift-argument-parser repo](https://github.com/apple/swift-argument-parser/blob/main/Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md).
 
 <details>
 <summary>Zsh, with oh-my-zsh:</summary>


### PR DESCRIPTION
Related issue #165