### PR TITLE
Setting universal build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ xcodes: $(SOURCES)
 		-Xswiftc -Onone \
 		--disable-sandbox \
 		--build-path "$(BUILDDIR)" \
+		--arch arm64 \
+		--arch x86_64 \
 
 .PHONY: sign
 sign: xcodes


### PR DESCRIPTION
Close #170

@MattKiazyk Might want to test this before merging. It looks like **maybe** the output executable might be in a different location. But since I'm not completely familiar with the build/distribution system of this project, I'm not sure that matters.

I was able to verify that the outputted executable from this PR does produce a universal binary tho.

Please let me know if any adjustments need to be made.