### PR TITLE
Do not exit(1) if xcode is already installed

### DIFF
--- a/Sources/xcodes/ParsableArguments+InstallError.swift
+++ b/Sources/xcodes/ParsableArguments+InstallError.swift
@@ -1,0 +1,30 @@
+import ArgumentParser
+import Foundation
+import LegibleError
+import PromiseKit
+import XcodesKit
+import Rainbow
+
+extension ParsableArguments {
+    static func processDownloadOrInstall(error: Error) -> Never {
+        var exitCode: ExitCode = .failure
+        switch error {
+        case Process.PMKError.execution(let process, let standardOutput, let standardError):
+            Current.logging.log("""
+                Failed executing: `\(process)` (\(process.terminationStatus))
+                \([standardOutput, standardError].compactMap { $0 }.joined(separator: "\n"))
+                """.red)
+        case let error as XcodeInstaller.Error:
+            if case .versionAlreadyInstalled = error {
+                Current.logging.log(error.legibleLocalizedDescription.green)
+                exitCode = .success
+            } else {
+                Current.logging.log(error.legibleLocalizedDescription.red)
+            }
+        default:
+            Current.logging.log(error.legibleLocalizedDescription.red)
+        }
+
+        Self.exit(withError: exitCode)
+    }
+}

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -138,17 +138,7 @@ struct Xcodes: ParsableCommand {
 
             installer.download(installation, dataSource: globalDataSource.dataSource, downloader: downloader, destinationDirectory: destination)
                 .catch { error in
-                    switch error {
-                    case Process.PMKError.execution(let process, let standardOutput, let standardError):
-                        Current.logging.log("""
-                            Failed executing: `\(process)` (\(process.terminationStatus))
-                            \([standardOutput, standardError].compactMap { $0 }.joined(separator: "\n"))
-                            """.red)
-                    default:
-                        Current.logging.log(error.legibleLocalizedDescription.red)
-                    }
-                    
-                    Install.exit(withError: ExitCode.failure)
+                    Install.processDownloadOrInstall(error: error)
                 }
             
             RunLoop.current.run()
@@ -231,17 +221,7 @@ struct Xcodes: ParsableCommand {
             installer.install(installation, dataSource: globalDataSource.dataSource, downloader: downloader, destination: destination)
                 .done { Install.exit() }
                 .catch { error in
-                    switch error {
-                    case Process.PMKError.execution(let process, let standardOutput, let standardError):
-                        Current.logging.log("""
-                            Failed executing: `\(process)` (\(process.terminationStatus))
-                            \([standardOutput, standardError].compactMap { $0 }.joined(separator: "\n"))
-                            """.red)
-                    default:
-                        Current.logging.log(error.legibleLocalizedDescription.red)
-                    }
-                    
-                    Install.exit(withError: ExitCode.failure)
+                    Install.processDownloadOrInstall(error: error)
                 }
             
             RunLoop.current.run()


### PR DESCRIPTION
When running `xcodes install x.x.x` if the Xcode version is already installed, do not exit(1). Instead, exit with a success.

Addresses https://github.com/RobotsAndPencils/xcodes/issues/142

Example:

<img width="652" alt="Screen Shot 2022-01-30 at 11 01 41 PM" src="https://user-images.githubusercontent.com/12048108/151737249-836b6664-3dfc-43ea-ab1d-67d267cfa1b3.png">