### PR TITLE
Exit immediately if trying to select currently selected xcode

### DIFF
--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -39,12 +39,11 @@ public func selectXcode(shouldPrint: Bool, pathOrVersion: String, directory: Pat
                 }
         }
         else {
-            // remove any whitespaces
             let pathToSelect = pathOrVersion.trimmingCharacters(in: .whitespacesAndNewlines)
             let currentPath = output.out.trimmingCharacters(in: .whitespacesAndNewlines)
 
             if pathToSelect == currentPath {
-                Current.logging.log("Xcode at path \(pathOrVersion) is already selected")
+                Current.logging.log("Xcode at path \(pathOrVersion) is already selected".green)
                 Current.shell.exit(0)
                 return Promise.value(())
             }

--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -22,8 +22,16 @@ public func selectXcode(shouldPrint: Bool, pathOrVersion: String, directory: Pat
             }
         }
 
+        let installedXcodes = Current.files.installedXcodes(directory)
         if let version = Version(xcodeVersion: pathOrVersion),
-           let installedXcode = Current.files.installedXcodes(directory).first(withVersion: version) {
+           let installedXcode = installedXcodes.first(withVersion: version) {
+            let selectedInstalledXcodeVersion = installedXcodes.first { output.out.hasPrefix($0.path.string) }.map { $0.version }
+            if installedXcode.version == selectedInstalledXcodeVersion {
+                Current.logging.log("Xcode \(version) is already selected")
+                Current.shell.exit(0)
+                return Promise.value(())
+            }
+
             return selectXcodeAtPath(installedXcode.path.string)
                 .done { output in
                     Current.logging.log("Selected \(output.out)".green)
@@ -31,7 +39,17 @@ public func selectXcode(shouldPrint: Bool, pathOrVersion: String, directory: Pat
                 }
         }
         else {
-            return selectXcodeAtPath(pathOrVersion)
+            // remove any whitespaces
+            let pathToSelect = pathOrVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+            let currentPath = output.out.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if pathToSelect == currentPath {
+                Current.logging.log("Xcode at path \(pathOrVersion) is already selected")
+                Current.shell.exit(0)
+                return Promise.value(())
+            }
+
+            return selectXcodeAtPath(pathToSelect)
                 .done { output in
                     Current.logging.log("Selected \(output.out)".green)
                     Current.shell.exit(0)
@@ -94,7 +112,7 @@ public func chooseFromInstalledXcodesInteractively(currentPath: String, director
         return Promise(error: error)
     }
 
-    return Promise.value(sortedInstalledXcodes[selectionNumber - 1]) 
+    return Promise.value(sortedInstalledXcodes[selectionNumber - 1])
 }
 
 public func selectXcodeInteractively(currentPath: String, directory: Path) -> Promise<ProcessOutput> {

--- a/Sources/XcodesKit/XcodeSelect.swift
+++ b/Sources/XcodesKit/XcodeSelect.swift
@@ -27,7 +27,7 @@ public func selectXcode(shouldPrint: Bool, pathOrVersion: String, directory: Pat
            let installedXcode = installedXcodes.first(withVersion: version) {
             let selectedInstalledXcodeVersion = installedXcodes.first { output.out.hasPrefix($0.path.string) }.map { $0.version }
             if installedXcode.version == selectedInstalledXcodeVersion {
-                Current.logging.log("Xcode \(version) is already selected")
+                Current.logging.log("Xcode \(version) is already selected".green)
                 Current.shell.exit(0)
                 return Promise.value(())
             }


### PR DESCRIPTION
If the currently requested xcode is already selected, there is no need to prompt the user to give sudo permissions and re-select the path. We can just avoid the step and exit early.

Closes https://github.com/RobotsAndPencils/xcodes/issues/102