### PR TITLE
Fix broken unit tests due to new logs and Xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
       env: 
-        DEVELOPER_DIR: /Applications/Xcode_12.3.app
+        DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
       run: swift test

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-AlternativeDirectory.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-AlternativeDirectory.txt
@@ -1,6 +1,8 @@
 Apple ID: 
 Apple ID Password: 
 
+Downloading with urlSession - for faster downloads install aria2 (`brew install aria2`)
+
 [1A[K(1/6) Downloading Xcode 0.0.0: 1%
 [1A[K(1/6) Downloading Xcode 0.0.0: 2%
 [1A[K(1/6) Downloading Xcode 0.0.0: 3%
@@ -102,6 +104,7 @@ Apple ID Password:
 [1A[K(1/6) Downloading Xcode 0.0.0: 99%
 [1A[K(1/6) Downloading Xcode 0.0.0: 100%
 (2/6) Unarchiving Xcode (This can take a while)
+Using regular unxip. Try passing `--experimental-unxip` for a faster unxip process
 (3/6) Moving Xcode to /Users/brandon/Xcode/Xcode-0.0.0.app
 (4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
 (5/6) Checking security assessment and code signing

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-DamagedXIP.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-DamagedXIP.txt
@@ -3,9 +3,12 @@ Apple ID Password:
 
 (1/6) Found existing archive that will be used for installation at /Users/brandon/Library/Application Support/com.robotsandpencils.xcodes/Xcode-0.0.0.xip.
 (2/6) Unarchiving Xcode (This can take a while)
+Using regular unxip. Try passing `--experimental-unxip` for a faster unxip process
 The archive "Xcode-0.0.0.xip" is damaged and can't be expanded.
 Removing damaged XIP and re-attempting installation.
 
+
+Downloading with urlSession - for faster downloads install aria2 (`brew install aria2`)
 
 [1A[K(1/6) Downloading Xcode 0.0.0: 1%
 [1A[K(1/6) Downloading Xcode 0.0.0: 2%
@@ -108,6 +111,7 @@ Removing damaged XIP and re-attempting installation.
 [1A[K(1/6) Downloading Xcode 0.0.0: 99%
 [1A[K(1/6) Downloading Xcode 0.0.0: 100%
 (2/6) Unarchiving Xcode (This can take a while)
+Using regular unxip. Try passing `--experimental-unxip` for a faster unxip process
 (3/6) Moving Xcode to /Applications/Xcode-0.0.0.app
 (4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
 (5/6) Checking security assessment and code signing

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NoColor.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NoColor.txt
@@ -1,6 +1,8 @@
 Apple ID: 
 Apple ID Password: 
 
+Downloading with urlSession - for faster downloads install aria2 (`brew install aria2`)
+
 [1A[K(1/6) Downloading Xcode 0.0.0: 1%
 [1A[K(1/6) Downloading Xcode 0.0.0: 2%
 [1A[K(1/6) Downloading Xcode 0.0.0: 3%
@@ -102,6 +104,7 @@ Apple ID Password:
 [1A[K(1/6) Downloading Xcode 0.0.0: 99%
 [1A[K(1/6) Downloading Xcode 0.0.0: 100%
 (2/6) Unarchiving Xcode (This can take a while)
+Using regular unxip. Try passing `--experimental-unxip` for a faster unxip process
 (3/6) Moving Xcode to /Applications/Xcode-0.0.0.app
 (4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
 (5/6) Checking security assessment and code signing

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NonInteractiveTerminal.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath-NonInteractiveTerminal.txt
@@ -2,6 +2,7 @@ Apple ID:
 Apple ID Password: 
 (1/6) Downloading Xcode 0.0.0
 (2/6) Unarchiving Xcode (This can take a while)
+Using regular unxip. Try passing `--experimental-unxip` for a faster unxip process
 (3/6) Moving Xcode to /Applications/Xcode-0.0.0.app
 (4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
 (5/6) Checking security assessment and code signing

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-FullHappyPath.txt
@@ -1,6 +1,8 @@
 Apple ID: 
 Apple ID Password: 
 
+[30;43mDownloading with urlSession - for faster downloads install aria2 (`brew install aria2`)[0m
+
 [1A[K(1/6) Downloading Xcode 0.0.0: 1%
 [1A[K(1/6) Downloading Xcode 0.0.0: 2%
 [1A[K(1/6) Downloading Xcode 0.0.0: 3%
@@ -102,6 +104,7 @@ Apple ID Password:
 [1A[K(1/6) Downloading Xcode 0.0.0: 99%
 [1A[K(1/6) Downloading Xcode 0.0.0: 100%
 (2/6) Unarchiving Xcode (This can take a while)
+Using regular unxip. Try passing `--experimental-unxip` for a faster unxip process
 (3/6) Moving Xcode to /Applications/Xcode-0.0.0.app
 (4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
 (5/6) Checking security assessment and code signing

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-IncorrectSavedPassword.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-IncorrectSavedPassword.txt
@@ -3,6 +3,8 @@ Invalid username and password combination. Attempted to sign in with username te
 Try entering your password again
 Apple ID Password (test@example.com): 
 
+Downloading with urlSession - for faster downloads install aria2 (`brew install aria2`)
+
 [1A[K(1/6) Downloading Xcode 0.0.0: 1%
 [1A[K(1/6) Downloading Xcode 0.0.0: 2%
 [1A[K(1/6) Downloading Xcode 0.0.0: 3%
@@ -104,6 +106,7 @@ Apple ID Password (test@example.com):
 [1A[K(1/6) Downloading Xcode 0.0.0: 99%
 [1A[K(1/6) Downloading Xcode 0.0.0: 100%
 (2/6) Unarchiving Xcode (This can take a while)
+Using regular unxip. Try passing `--experimental-unxip` for a faster unxip process
 (3/6) Moving Xcode to /Applications/Xcode-0.0.0.app
 (4/6) Moving Xcode archive Xcode-0.0.0.xip to the Trash
 (5/6) Checking security assessment and code signing


### PR DESCRIPTION
There were unit tests that broke due to recent changes. Fixing the broken fixture files and also changing the CI to use Xcode 13 as that is now required to build the package