### PR TITLE
Update Makefile - refactor swift-build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ xcodes: $(SOURCES)
 		--configuration release \
 		-Xswiftc -Onone \
 		--disable-sandbox \
-		--build-path "$(BUILDDIR)" \
+		--scratch-path "$(BUILDDIR)" \
 		--arch arm64 \
 		--arch x86_64 \
 


### PR DESCRIPTION
trying to fix warning message comes from `swift build` during installation with `brew`.

`"warning: '--build-path' option is deprecated; use '--scratch-path' instead"`

reason: https://github.com/apple/swift-package-manager/pull/4195