### PR TITLE
Add ability to download Xcode without logging in using XcodeRelease

### DIFF
--- a/Sources/XcodesKit/Models.swift
+++ b/Sources/XcodesKit/Models.swift
@@ -50,6 +50,10 @@ public struct Xcode: Codable, Equatable {
     public let filename: String
     public let releaseDate: Date?
 
+    public var downloadPath: String {
+        return url.path
+    }
+    
     public init(version: Version, url: URL, filename: String, releaseDate: Date?) {
         self.version =  version
         self.url = url

--- a/Sources/XcodesKit/URLRequest+Apple.swift
+++ b/Sources/XcodesKit/URLRequest+Apple.swift
@@ -4,6 +4,7 @@ extension URL {
     static let download = URL(string: "https://developer.apple.com/download")!
     static let downloads = URL(string: "https://developer.apple.com/services-account/QH65B2/downloadws/listDownloads.action")!
     static let downloadXcode = URL(string: "https://developer.apple.com/devcenter/download.action")!
+    static let downloadADCAuth = URL(string: "https://developerservices2.apple.com/services/download")!
 }
 
 extension URLRequest {
@@ -19,6 +20,16 @@ extension URLRequest {
 
     static func downloadXcode(path: String) -> URLRequest {
         var components = URLComponents(url: .downloadXcode, resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "path", value: path)]
+        var request = URLRequest(url: components.url!)
+        request.allHTTPHeaderFields = request.allHTTPHeaderFields ?? [:]
+        request.allHTTPHeaderFields?["Accept"] = "*/*"
+        return request
+    }
+    
+    // default to a known download path if none passed in
+    static func downloadADCAuth(path: String? = "/Developer_Tools/Xcode_14/Xcode_14.xip") -> URLRequest {
+        var components = URLComponents(url: .downloadADCAuth, resolvingAgainstBaseURL: false)!
         components.queryItems = [URLQueryItem(name: "path", value: path)]
         var request = URLRequest(url: components.url!)
         request.allHTTPHeaderFields = request.allHTTPHeaderFields ?? [:]


### PR DESCRIPTION
I hate having to log into my Apple Developer account, always having to put in my 2fa code, when I want to download Xcode, but Apple has never given us the ability to do so.

As a CI user, it sucks that I have to type in my credentials all the time, while trying to do a xcode install on multiple machines. 

This PR changes that.

By using a public URL provided by Apple, we can get a token cookie that can be used to download the version of Xcode that we wish, without having to provide a log in. 🎉 

Caveats:
- This does not work when using the `Apple` datasource. More specifically that token doesn't work for listing the Xcode versions with `https://developer.apple.com/services-account/QH65B2/downloadws/listDownloads.action` 

