### PR TITLE
Add "version" argument to "installed" function, printing Xcode's installation path

### DIFF
--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -762,6 +762,21 @@ public final class XcodeInstaller {
             }
     }
 
+    public func printXcodePath(ofVersion versionString: String, searchingIn directory: Path) -> Promise<Void> {
+        return firstly { () -> Promise<Void> in
+            guard let version = Version(xcodeVersion: versionString) else {
+                throw Error.invalidVersion(versionString)
+            }
+            let installedXcodes = Current.files.installedXcodes(directory)
+                .sorted { $0.version < $1.version }
+            guard let installedXcode = installedXcodes.first(withVersion: version) else {
+                throw Error.versionNotInstalled(version)
+            }
+            Current.logging.log(installedXcode.path.string)
+            return Promise.value(())
+        }
+    }
+
     func unarchiveAndMoveXIP(at source: URL, to destination: URL, experimentalUnxip: Bool) -> Promise<URL> {
         return firstly { () -> Promise<Void> in
             Current.logging.log(InstallationStep.unarchiving(experimentalUnxip: experimentalUnxip).description)


### PR DESCRIPTION
## Description

Resolves #219

This is another initiative that powers https://github.com/xcpretty/xcode-install/issues/467

With the resolution of #219, we can have a smoother transition from `xcode-install` to `xcodes`, including on _fastlane_ integrations.

See also: https://github.com/fastlane/fastlane/pull/20672