### PR TITLE
Use mocks when writing the cache file in unit tests

### DIFF
--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -213,6 +213,12 @@ public struct Files {
         return contentsAtPath(path)
     }
 
+    public var write: (Data, URL) throws -> Void = { try $0.write(to: $1) }
+
+    public func write(_ data: Data, to url: URL) throws {
+        try write(data, url)
+    }
+
     public var removeItem: (URL) throws -> Void = { try FileManager.default.removeItem(at: $0) }
 
     public func removeItem(at URL: URL) throws {

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -55,7 +55,7 @@ extension XcodeList {
         let data = try JSONEncoder().encode(xcodes)
         try FileManager.default.createDirectory(at: Path.cacheFile.url.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
-        try data.write(to: Path.cacheFile.url)
+        try Current.files.write(data, to: Path.cacheFile.url)
     }
 }
 

--- a/Tests/XcodesKitTests/Environment+Mock.swift
+++ b/Tests/XcodesKitTests/Environment+Mock.swift
@@ -56,6 +56,7 @@ extension Files {
                 return nil
             }
         },
+        write: { _, _ in },
         removeItem: { _ in },
         trashItem: { _ in return URL(fileURLWithPath: "\(NSHomeDirectory())/.Trash") },
         createFile: { _, _, _ in return true },


### PR DESCRIPTION
After running the unit tests while working on #226, I noticed `xcodes list` was returning fake versions of Xcode. It looks like this is actually a pre-existing issue with the unit tests, so I figured I'd open a separate PR to fix it.