### PR TITLE
Install from build identifier

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcodes.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcodes.xcscheme
@@ -128,6 +128,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "install --build 13A5201i"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "runtimes"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Sources/XcodesKit/Build.swift
+++ b/Sources/XcodesKit/Build.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct Build: Equatable, CustomStringConvertible {
+    
+    let identifier: String
+    
+    /**
+     E.g.:
+     13E500a
+     12E507
+     7B85
+     */
+    init?(identifier: String) {
+        let nsrange = NSRange(identifier.startIndex..<identifier.endIndex, in: identifier)
+        let pattern = "^\\d+[A-Z]\\d+[a-z]*$"
+        guard
+            let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+            regex.firstMatch(in: identifier, options: [], range: nsrange) != nil else {
+            return nil
+        }
+        self.identifier = identifier
+    }
+    
+    public var description: String { identifier }
+}

--- a/Sources/xcodes/App.swift
+++ b/Sources/xcodes/App.swift
@@ -180,6 +180,9 @@ struct Xcodes: AsyncParsableCommand {
                 completion: .file(extensions: ["xip"]))
         var pathString: String?
         
+        @Flag(help: "Install a specific build number of Xcode.")
+        var build = false
+        
         @Flag(help: "Update and then install the latest non-prerelease version available.")
         var latest: Bool = false
         
@@ -224,6 +227,8 @@ struct Xcodes: AsyncParsableCommand {
                 installation = .latestPrerelease
             } else if let pathString = pathString, let path = Path(pathString) {
                 installation = .path(versionString, path)
+            } else if build {
+                installation = .build(versionString)
             } else {
                 installation = .version(versionString)
             }

--- a/Tests/XcodesKitTests/Build+XcodeTests.swift
+++ b/Tests/XcodesKitTests/Build+XcodeTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import XcodesKit
+
+class BuildXcodeTests: XCTestCase {
+    
+    func test_InitXcodeVersion() {
+        XCTAssertNotNil(Build(identifier: "13E500a"))
+        XCTAssertNotNil(Build(identifier: "12E507"))
+        XCTAssertNotNil(Build(identifier: "7B85"))
+        XCTAssertNil(Build(identifier: "13.1.0"))
+        XCTAssertNil(Build(identifier: "13"))
+        XCTAssertNil(Build(identifier: "14B"))
+    }
+    
+}


### PR DESCRIPTION
Xcode has build identifiers that identify a version uniquely. When using `xcodes list` the following Xcode build identifiers, which are rendered in paranthesis (e.g. `14A30`) are available:

```sh
1.0 (7B85)
1.5 (7K571)
2.2.1 (8G1165)
[…]
13.4 (13F17a)
13.4.1 (13F100)
14.0 Beta (14A5228q)
14.0 Beta 2 (14A5229c)
14.0 Beta 3 (14A5270f)
14.0 Beta 4 (14A5284g)
14.0 Beta 5 (14A5294e)
14.0 Beta 6 (14A5294g)
14.0 (14A309)
14.0.1 (14A400)
```

This PR adds the possibility to install a version of Xcode by specifying the build identifier, which can easily be copied from most terminals by double clicking the identifier, copying it and then typing `xcodes install --build ` and pasting the identifier:

```sh
xcodes install --build 14A400
```

Out of scope of this PR:
I would have liked to match the build identifier without specifying the `--build` flag, but as xcodes heavily relies on semantic versioning this would have been a much more complex change in the current code base. However, by introducing this purely additive flag, we could leverage this later to do include the build identifier when fuzzy searching the Xcode version.