### PR TITLE
use simpler 'release' instead of 'non-prerelease' word in user-facing…

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You'll need Xcode 13 in order to build and run xcodes.
 
 <details>
 <summary>Using Xcode</summary>
-Even though xcodes is a command-line app, lll of the normal functionality works in Xcode, like building, running, and running tests. You can even type text into Xcode's console when it prompts you for input like your Apple ID or 2FA code.
+Even though xcodes is a command-line app, all of the normal functionality works in Xcode, like building, running, and running tests. You can even type text into Xcode's console when it prompts you for input like your Apple ID or 2FA code.
 
 When running xcodes from Xcode, if you want to run a particular command or pass some arguments, you can hold the option key to present a sheet with more options. This means you'd use <kbd>Option</kbd> + <kbd>Command</kbd> + <kbd>R</kbd> or hold <kbd>Option</kbd> while clicking the Run button. Here you can add, remove, and toggle arguments that will be passed to xcodes when it's launched.
 

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -21,7 +21,7 @@ public final class XcodeInstaller {
         case unsupportedFileFormat(extension: String)
         case missingSudoerPassword
         case unavailableVersion(Version)
-        case noNonPrereleaseVersionAvailable
+        case noReleaseVersionAvailable
         case noPrereleaseVersionAvailable
         case versionAlreadyInstalled(InstalledXcode)
         case invalidVersion(String)
@@ -60,7 +60,7 @@ public final class XcodeInstaller {
                 return "Missing password. Please try again."
             case let .unavailableVersion(version):
                 return "Could not find version \(version.appleDescription)."
-            case .noNonPrereleaseVersionAvailable:
+            case .noReleaseVersionAvailable:
                 return "No release versions available."
             case .noPrereleaseVersionAvailable:
                 return "No prerelease versions available."
@@ -222,17 +222,17 @@ public final class XcodeInstaller {
 
                 return update(dataSource: dataSource)
                     .then { availableXcodes -> Promise<(Xcode, URL)> in
-                        guard let latestNonPrereleaseXcode = availableXcodes.filter(\.version.isNotPrerelease).sorted(\.version).last else {
-                            throw Error.noNonPrereleaseVersionAvailable
+                        guard let latestReleaseXcode = availableXcodes.filter(\.version.isNotPrerelease).sorted(\.version).last else {
+                            throw Error.noReleaseVersionAvailable
                         }
 
-                        Current.logging.log("Latest release version available is \(latestNonPrereleaseXcode.version.appleDescription)")
+                        Current.logging.log("Latest release version available is \(latestReleaseXcode.version.appleDescription)")
                         
-                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestNonPrereleaseXcode.version) }) {
+                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestReleaseXcode.version) }) {
                             throw Error.versionAlreadyInstalled(installedXcode)
                         }
 
-                        return self.downloadXcode(version: latestNonPrereleaseXcode.version, dataSource: dataSource, downloader: downloader, willInstall: willInstall)
+                        return self.downloadXcode(version: latestReleaseXcode.version, dataSource: dataSource, downloader: downloader, willInstall: willInstall)
                     }
             case .latestPrerelease:
                 Current.logging.log("Updating...")
@@ -245,7 +245,7 @@ public final class XcodeInstaller {
                             .sorted(by: { $0.releaseDate! < $1.releaseDate! })
                             .last
                         else {
-                            throw Error.noNonPrereleaseVersionAvailable
+                            throw Error.noReleaseVersionAvailable
                         }
                         Current.logging.log("Latest prerelease version available is \(latestPrereleaseXcode.version.appleDescription)")
 

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -61,7 +61,7 @@ public final class XcodeInstaller {
             case let .unavailableVersion(version):
                 return "Could not find version \(version.appleDescription)."
             case .noNonPrereleaseVersionAvailable:
-                return "No non-prerelease versions available."
+                return "No release versions available."
             case .noPrereleaseVersionAvailable:
                 return "No prerelease versions available."
             case let .versionAlreadyInstalled(installedXcode):
@@ -225,8 +225,9 @@ public final class XcodeInstaller {
                         guard let latestNonPrereleaseXcode = availableXcodes.filter(\.version.isNotPrerelease).sorted(\.version).last else {
                             throw Error.noNonPrereleaseVersionAvailable
                         }
-                        Current.logging.log("Latest non-prerelease version available is \(latestNonPrereleaseXcode.version.appleDescription)")
 
+                        Current.logging.log("Latest release version available is \(latestNonPrereleaseXcode.version.appleDescription)")
+                        
                         if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestNonPrereleaseXcode.version) }) {
                             throw Error.versionAlreadyInstalled(installedXcode)
                         }

--- a/Sources/xcodes/App.swift
+++ b/Sources/xcodes/App.swift
@@ -103,7 +103,7 @@ struct Xcodes: AsyncParsableCommand {
                   completion: .custom { args in xcodeList.availableXcodes.sorted { $0.version < $1.version }.map { $0.version.appleDescription } })
         var version: [String] = []
 
-        @Flag(help: "Update and then download the latest non-prerelease version available.")
+        @Flag(help: "Update and then download the latest release version available.")
         var latest: Bool = false
 
         @Flag(help: "Update and then download the latest prerelease version available, including GM seeds and GMs.")
@@ -184,7 +184,7 @@ struct Xcodes: AsyncParsableCommand {
                 completion: .file(extensions: ["xip"]))
         var pathString: String?
 
-        @Flag(help: "Update and then install the latest non-prerelease version available.")
+        @Flag(help: "Update and then install the latest release version available.")
         var latest: Bool = false
 
         @Flag(help: "Update and then install the latest prerelease version available, including GM seeds and GMs.")


### PR DESCRIPTION
… output

Hi,

Not sure if you'll find this PR useful and corresponding to your philosophy, but anyway...

I find current phrasing `Latest non-prerelease version available is...` a bit too complex. I would suggest to simplify it by replacing `non-prerelease` to plain... `release`.

I see that the same `NonPrerelease` term is used in variable names. If you find this suggestion feasible, then I can rename variables too.

Maybe you'll tell me that there's some deep idea behind `non-prerelease`, then I'm fine with that too :)

Thanks for the great tool that saves ton of my time!