### PR TITLE
restore downloading via xcodereleases with apple username/password :(

### DIFF
--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -286,7 +286,7 @@ public final class XcodeInstaller {
                     // session once we're ready to download Xcode. Doing that requires us to know the
                     // URL we want to download though (and we may not know that yet), so we don't need
                     // to do anything session-related quite yet.
-                    return Promise()
+                    return sessionService.loginIfNeeded()
             }
         }
         .then { () -> Promise<Void> in
@@ -313,7 +313,12 @@ public final class XcodeInstaller {
             case .xcodeReleases:
                     /// Now that we've used Xcode Releases to determine what URL we should use to
                     /// download Xcode, we can use that to establish an anonymous session with Apple.
-                    return self.sessionService.validateADCSession(path: xcode.downloadPath).map { xcode }
+                    // As of Nov 2022, the `validateADCSession` return 403 forbidden for Xcode versions (works with runtimes)
+                    // return self.sessionService.validateADCSession(path: xcode.downloadPath).map { xcode }
+                    // -------
+                    // We need the cookies from its response in order to download Xcodes though,
+                    // so perform it here first just to be sure.
+                    return Current.network.dataTask(with: URLRequest.downloads).map { _ in xcode }
             }
         }
         .then { xcode -> Promise<(Xcode, URL)> in


### PR DESCRIPTION
In Sept 2022, Xcodes was updated to use the same mechanism that is used to download runtimes with no login, to download Xcode. 

ie: https://developerservices2.apple.com/services/download?path=/Developer_Tools/tvOS_16.1_Simulator_Runtime/tvOS_16.1_Simulator_Runtime.dmg returns 200 to set the `ADCDownloadAuth` cookie to be able to download

As of mid Nov 2022, Apple has return 403 (forbidden) for this endpoint for Xcode versions only. Runtimes still return 200. 

https://developerservices2.apple.com/services/download?path=/Developer_Tools/Xcode_14.0.1/Xcode_14.0.1.xip

I'm not sure if this is deliberate from Apple (My guess is it is), but this PR reinstates the old way of download xcodes as all libraries and utilities have done for years now.

I don't think Apple will ever allow this open again. I do hope at some point, there is a way that I can use app specific passwords, or some other means, where I don't have to ask for a dev's Apple username/password.

More discussion is in #243 

#SadMatt