### PR TITLE
Better Handling of Apple Unauthorized errors

### DIFF
--- a/Sources/XcodesKit/Downloader.swift
+++ b/Sources/XcodesKit/Downloader.swift
@@ -49,7 +49,15 @@ public enum Downloader {
                                                                    to: destination.url,
                                                                    resumingWith: resumeData ?? persistedResumeData)
             progressChanged(progress)
-            return promise.map { $0.saveLocation }
+            return promise.map { result in
+                /// If the operation is unauthorized, the download page redirects to https://developer.apple.com/unauthorized/
+                /// with 200 status. After that the html page is downloaded as a xip and subsequent unxipping fails
+                guard result.response.url?.lastPathComponent != "unauthorized" else {
+                    throw XcodeInstaller.Error.unauthorized
+                }
+                
+                return result.saveLocation
+            }
         }
         .tap { result in
             self.persistOrCleanUpResumeData(at: resumeDataPath, for: result)

--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -95,6 +95,10 @@ public struct Shell {
         process.standardError = stdErrPipe
 
         var progress = Progress(totalUnitCount: 100)
+        
+        // We hold on to the unauthorized status
+        // So that we can properly throw error from inside the promise
+        var unauthorized = false
 
         let observer = NotificationCenter.default.addObserver(
             forName: .NSFileHandleDataAvailable,
@@ -110,6 +114,13 @@ public struct Shell {
             defer { handle.waitForDataInBackgroundAndNotify() }
 
             let string = String(decoding: handle.availableData, as: UTF8.self)
+            
+            /// If the operation is unauthorized, the download page redirects to https://developer.apple.com/unauthorized/
+            /// with 200 status. After that the html page is downloaded as a xip and subsequent unxipping fails
+            if !unauthorized && string.contains("Redirecting to https://developer.apple.com/unauthorized/") {
+                unauthorized = true
+            }
+            
             let regex = try! NSRegularExpression(pattern: #"((?<percent>\d+)%\))"#)
             let range = NSRange(location: 0, length: string.utf16.count)
 
@@ -143,6 +154,9 @@ public struct Shell {
                     } else {
                         return seal.reject(Process.PMKError.execution(process: process, standardOutput: "", standardError: ""))
                     }
+                }
+                guard !unauthorized else {
+                    return seal.reject(XcodeInstaller.Error.unauthorized)
                 }
                 seal.fulfill(())
             }

--- a/Sources/XcodesKit/Promise+.swift
+++ b/Sources/XcodesKit/Promise+.swift
@@ -15,6 +15,11 @@ func attemptResumableTask<T>(
                 attempts < maximumRetryCount,
                 let resumeData = (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data
             else { throw error }
+            
+            // Don't retry unauthorized errors because it won't change the outcome
+            if case XcodeInstaller.Error.unauthorized = error {
+                throw error
+            }
 
             return after(delayBeforeRetry).then(on: nil) { attempt(with: resumeData) }
         }
@@ -33,6 +38,12 @@ func attemptRetryableTask<T>(
         attempts += 1
         return body().recover { error -> Promise<T> in
             guard attempts < maximumRetryCount else { throw error }
+            
+            // Don't retry unauthorized errors because it won't change the outcome
+            if case XcodeInstaller.Error.unauthorized = error {
+                throw error
+            }
+            
             return after(delayBeforeRetry).then(on: nil) { attempt() }
         }
     }

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -26,6 +26,7 @@ public final class XcodeInstaller {
         case versionAlreadyInstalled(InstalledXcode)
         case invalidVersion(String)
         case versionNotInstalled(Version)
+        case unauthorized
 
         public var errorDescription: String? {
             switch self {
@@ -70,6 +71,12 @@ public final class XcodeInstaller {
                 return "\(version) is not a valid version number."
             case let .versionNotInstalled(version):
                 return "\(version.appleDescription) is not installed."
+            case .unauthorized:
+                return """
+                        Received 403: Unauthorized. This can happen when either:
+                        1. Apple Developer Terms and Conditions were not accepted at https://developer.apple.com/
+                        2. Apple ID authorization was revoked for some other reason
+                       """
             }
         }
     }


### PR DESCRIPTION
If a new Apple ID account doesn't accept Developer Agreement at https://developer.apple.com/ then Xcode download will fail with Unauthorized error

However, the way Apple handles unauthorized errors is by redirecting to https://developer.apple.com/unauthorized/ and happily returning 200. Therefore the only way to check for authorization is to catch this redirect. If we don't do this, then unauthorized html will be downloaded and attempted to be unxipped, so the xcodes will fail with a "corrupted xip" error.

Therefore this PR:
1. Attempts to catch unauthorized redirect and throw error
2. Adds a descriptive message when this error is thrown
3. Prevents retries in case of 403. Retrying won't help, so it's better to terminate early

How to test:
1. In the `XcodeInstaller.swift` replace all instances of `sessionService.loginIfNeeded()` with `Promise()`
2. `xcodes signout`
3. Try to download e.g. `xcodes install 14.0`

Before the change you would get "corrupted xip message", after the change you would get a nice descriptive message.

It's all very hacky, I would love to hear suggestions on how to improve the PR