### PR TITLE
Prevent keyNotFound error with unknown simulators

### DIFF
--- a/Sources/XcodesKit/Models+Runtimes.swift
+++ b/Sources/XcodesKit/Models+Runtimes.swift
@@ -86,6 +86,7 @@ extension DownloadableRuntime {
         case macOS = "com.apple.platform.macosx"
         case watchOS = "com.apple.platform.watchos"
         case tvOS = "com.apple.platform.appletvos"
+        case unknown = ""
 
         var order: Int {
             switch self {
@@ -93,6 +94,7 @@ extension DownloadableRuntime {
                 case .macOS: return 2
                 case .watchOS: return 3
                 case .tvOS: return 4
+                case .unknown: return 5
             }
         }
 
@@ -102,24 +104,25 @@ extension DownloadableRuntime {
                 case .macOS: return "macOS"
                 case .watchOS: return "watchOS"
                 case .tvOS: return "tvOS"
+                case .unknown: return "Unknown"
             }
         }
     }
 }
 
 public struct InstalledRuntime: Decodable {
-    let build: String
+    let build: String?
     let deletable: Bool
     let identifier: UUID
     let kind: Kind
     let lastUsedAt: Date?
     let path: String
-    let platformIdentifier: Platform
-    let runtimeBundlePath: String
-    let runtimeIdentifier: String
+    let platformIdentifier: Platform?
+    let runtimeBundlePath: String?
+    let runtimeIdentifier: String?
     let signatureState: String
     let state: String
-    let version: String
+    let version: String?
     let sizeBytes: Int?
 }
 

--- a/Sources/XcodesKit/RuntimeInstaller.swift
+++ b/Sources/XcodesKit/RuntimeInstaller.swift
@@ -43,13 +43,13 @@ public class RuntimeInstaller {
 
         installed.forEach { runtime in
             let resolvedBetaNumber = downloadablesResponse.sdkToSeedMappings.first {
-                $0.buildUpdate == runtime.build
+                $0.buildUpdate == runtime.build ?? ""
             }?.seedNumber
 
-            var result = PrintableRuntime(platform: runtime.platformIdentifier.asPlatformOS,
+            var result = PrintableRuntime(platform: runtime.platformIdentifier?.asPlatformOS ?? .unknown,
                                           betaNumber: resolvedBetaNumber,
-                                          version: runtime.version,
-                                          build: runtime.build,
+                                          version: runtime.version ?? "0",
+                                          build: runtime.build ?? "",
                                           state: runtime.kind)
 
             mappedRuntimes.indices {


### PR DESCRIPTION
This pull request prevents the following error when running `xcodes runtimes` when an "Unknown Platform Simulator" is installed:
```
Error: keyNotFound(CodingKeys(stringValue: "build", intValue: nil), Swift.DecodingError.Context(codingPath: [_JSONKey(stringValue: "820783CB-C389-4006-B2D2-D063F3FD10A1", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"build\", intValue: nil) (\"build\").", underlyingError: nil))
```

If one accidentally runs `xcrun simctl runtime add` with an incompatible pre-iOS 16 Simulator runtime:
```
xcrun simctl runtime add com.apple.pkg.iPhoneSimulatorSDK15_0-15.0.1.1633542405.dmg
```

The following error will be displayed:
```
D: 94DEF0B1-1585-4D71-AB37-98AB08FDD000 <unknown platform> (Unusable - Missing Signature: Error Domain=SimDiskImageErrorDomain Code=3 "Missing Signature" UserInfo={NSLocalizedDescription=Missing Signature, unusableErrorDetail=})
```

The problem is that it's not immediately obvious that Xcode has still installed the runtime, but with a  missing signature state:
![PixelSnap 2023-01-04 at 07 50 16@2x](https://user-images.githubusercontent.com/2276355/210500459-f0f4d6e0-c2b4-4e7d-9d1c-f65d960c129f.png)

And when xcodes runs `xcrun simctl runtime list -j`, there is no `build` key resulting in the error:
```
"820783CB-C389-4006-B2D2-D063F3FD10A1" : {
  "deletable" : true,
  "identifier" : "820783CB-C389-4006-B2D2-D063F3FD10A1",
  "kind" : "Disk Image",
  "path" : "\/Library\/Developer\/CoreSimulator\/Images\/Inbox\/820783CB-C389-4006-B2D2-D063F3FD10A1.dmg",
  "signatureState" : "Missing",
  "sizeBytes" : 5304795932,
  "state" : "Unusable",
  "unusableErrorDetail" : "Error Domain=SimDiskImageErrorDomain Code=3 \"Missing Signature\" UserInfo={NSLocalizedDescription=Missing Signature, unusableErrorDetail=}",
  "unusableErrorMessage" : "Missing Signature",
  "unusableSubstate" : "Missing Signature"
}
```

This change results in the following `xcodes runtimes` output:
```
-- Unknown --
Unknown 0 (Downloaded)
```

Another approach could be to filter out undecodable runtimes in the `RuntimeList` class, this actually resulted in more code though.