### PR TITLE
Added support for fastlane auth cookies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "data",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/xcodereleases/data.git",
+      "location" : "https://github.com/xcodereleases/data",
       "state" : {
         "revision" : "fcf527b187817f67c05223676341f3ab69d4214d"
       }
@@ -87,6 +87,15 @@
       "state" : {
         "revision" : "087c91fedc110f9f833b14ef4c32745dabca8913",
         "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "01835dc202670b5bb90d07f3eae41867e9ed29f6",
+        "version" : "5.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.2.0")),
         .package(url: "https://github.com/xcodereleases/data", revision: "fcf527b187817f67c05223676341f3ab69d4214d"),
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMinor(from: "3.2.0")),
+        .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "5.0.1")),
     ],
     targets: [
         .executableTarget(
@@ -49,6 +50,7 @@ let package = Package(
                 "Version",
                 .product(name: "XCModel", package: "data"),
                 "Rainbow",
+                "Yams"
             ]),
         .testTarget(
             name: "XcodesKitTests",

--- a/Sources/XcodesKit/AppleSessionService.swift
+++ b/Sources/XcodesKit/AppleSessionService.swift
@@ -39,6 +39,12 @@ public class AppleSessionService {
 
     func loginIfNeeded(withUsername providedUsername: String? = nil, shouldPromptForPassword: Bool = false) -> Promise<Void> {
         return firstly { () -> Promise<Void> in
+            Promise { promise in
+                FastlaneCookieLoader().load(in: AppleAPI.Current.network.session.configuration.httpCookieStorage)
+                promise.fulfill(())
+            }
+        }
+        .then { () -> Promise<Void> in
             return Current.network.validateSession()
         }
         // Don't have a valid session, so we'll need to log in

--- a/Sources/XcodesKit/FastlaneCookieLoader.swift
+++ b/Sources/XcodesKit/FastlaneCookieLoader.swift
@@ -1,0 +1,60 @@
+//
+//  FastlaneCookieLoader.swift
+//  
+//
+//  Created by Omar Zuñiga on 09/01/23.
+//
+
+import Foundation
+import Yams
+
+struct FastlaneCookieLoader {
+    
+    private let fastlaneSession = "FASTLANE_SESSION"
+    
+    func load(in storage: HTTPCookieStorage?) {
+        do {
+            guard let storage, var sessionVar = Current.shell.env(fastlaneSession) else { return }
+            // We need to convert literal line break into actual ones
+            sessionVar = sessionVar.replacingOccurrences(of: "\\n", with: "\n")
+            let decoder = YAMLDecoder()
+            let cookies: [Cookie] = try decoder.decode(from: sessionVar)
+            cookies.forEach { add(cookie: $0, in: storage) }
+        } catch {
+          print("Error decoding Fastlane cookie: \(error)")
+        }
+    }
+}
+
+private extension FastlaneCookieLoader {
+    func add(cookie: Cookie, in storage: HTTPCookieStorage) {
+        
+        // apple.com cookies are supposed to be for all apple.com requests
+        let domain = cookie.domain == "apple.com" ? ".apple.com" : cookie.domain
+        
+        let properties: [HTTPCookiePropertyKey: Any] =  [
+            .name: cookie.name,
+            .value: cookie.value,
+            .domain: domain,
+            .path: cookie.path,
+            .expires: cookie.expires,
+            .secure: cookie.secure.flatMap { String($0) },
+            .maximumAge: cookie.maxAge.flatMap { String($0) },
+            .originURL: cookie.origin,
+        ].compactMapValues { $0 }
+        
+        guard let httpCookie = HTTPCookie(properties: properties) else { return }
+        storage.setCookie(httpCookie)
+    }
+}
+
+private struct Cookie: Decodable {
+     let name: String?
+     let value: String?
+     let domain: String?
+     let path: String?
+     let expires: String?
+     let secure: Bool?
+     let maxAge: UInt?
+     let origin: String?
+ }


### PR DESCRIPTION
Solves issue https://github.com/RobotsAndPencils/xcodes/issues/141
Inspired by this fork commit: https://github.com/tahirmt/xcodes/commit/2da7761d34ace622044b2780b971d4c0c06b83d8

fastlane spaceauth generates a YML session string so we can parse it directly and inject those cookies into the session's cookies storage.

I kept the `FASTLANE_SESSION` env var name to have direct support with fastlane.

**Steps**

You will now be able to download Xcode in CI environments by first running locally:

```
fastlane spaceauth -u username@email.com
```

And then in your CI scripts you can export the variable and run `xcodes`, it won't prompt for username/password/2fa:

```
export  FASTLANE_SESSION='---\n-.......'
xcodes download 14.0
```

References:
https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/client.rb#L280
https://github.com/sparklemotion/http-cookie/blob/master/lib/http/cookie_jar/yaml_saver.rb#L19