### PR TITLE
Add a download runtimes command

### DIFF
--- a/Sources/XcodesKit/Downloader.swift
+++ b/Sources/XcodesKit/Downloader.swift
@@ -7,6 +7,14 @@ public enum Downloader {
     case urlSession
     case aria2(Path)
 
+    public init(aria2Path: String?) {
+        guard let aria2Path = aria2Path.flatMap(Path.init) ?? Current.shell.findExecutable("aria2c"), aria2Path.exists else {
+            self = .urlSession
+            return
+        }
+        self = .aria2(aria2Path)
+    }
+
     func download(url: URL, to destination: Path, progressChanged: @escaping (Progress) -> Void) -> Promise<URL> {
         switch self {
             case .urlSession:

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-Runtime_NoBetas.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-Runtime_NoBetas.txt
@@ -1,7 +1,7 @@
 -- iOS --
-iOS 12.4 (Downloaded)
-iOS 13.0 (Downloaded)
-iOS 13.1 (Downloaded)
+iOS 12.4 (Installed)
+iOS 13.0 (Installed)
+iOS 13.1 (Installed)
 iOS 13.2.2
 iOS 13.3
 iOS 13.4
@@ -18,7 +18,7 @@ iOS 15.0
 iOS 15.2
 iOS 15.4
 iOS 15.5 (Bundled with selected Xcode)
-iOS 15.5 (Downloaded)
+iOS 15.5 (Installed)
 iOS 16.0
 -- watchOS --
 watchOS 6.0
@@ -31,9 +31,9 @@ watchOS 7.4
 watchOS 8.0
 watchOS 8.3
 watchOS 8.5 (Bundled with selected Xcode)
-watchOS 9.0-beta4 (Downloaded)
+watchOS 9.0-beta4 (Installed)
 watchOS 9.0 (20R362)
-watchOS 9.0 (UnknownBuildNumber) (Downloaded)
+watchOS 9.0 (UnknownBuildNumber) (Installed)
 -- tvOS --
 tvOS 12.4
 tvOS 13.0

--- a/Tests/XcodesKitTests/Fixtures/LogOutput-Runtimes.txt
+++ b/Tests/XcodesKitTests/Fixtures/LogOutput-Runtimes.txt
@@ -1,7 +1,7 @@
 -- iOS --
-iOS 12.4 (Downloaded)
-iOS 13.0 (Downloaded)
-iOS 13.1 (Downloaded)
+iOS 12.4 (Installed)
+iOS 13.0 (Installed)
+iOS 13.1 (Installed)
 iOS 13.2.2
 iOS 13.3
 iOS 13.4
@@ -18,7 +18,7 @@ iOS 15.0
 iOS 15.2
 iOS 15.4
 iOS 15.5 (Bundled with selected Xcode)
-iOS 15.5 (Downloaded)
+iOS 15.5 (Installed)
 iOS 16.0
 -- watchOS --
 watchOS 6.0
@@ -34,10 +34,10 @@ watchOS 8.5 (Bundled with selected Xcode)
 watchOS 9.0-beta1
 watchOS 9.0-beta2
 watchOS 9.0-beta3
-watchOS 9.0-beta4 (Downloaded)
+watchOS 9.0-beta4 (Installed)
 watchOS 9.0-beta5
 watchOS 9.0 (20R362)
-watchOS 9.0 (UnknownBuildNumber) (Downloaded)
+watchOS 9.0 (UnknownBuildNumber) (Installed)
 watchOS 9.1-beta1
 -- tvOS --
 tvOS 12.4


### PR DESCRIPTION
Resolves #262.

Also changed the word "Downloaded" to "Installed" in the runtimes list to avoid confusion.