### PR TITLE
Bump swift-argument-parser to 1.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -76,8 +76,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {
@@ -92,7 +92,7 @@
     {
       "identity" : "swift-srp",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/xcodesorg/swift-srp",
+      "location" : "https://github.com/xcodesOrg/swift-srp",
       "state" : {
         "branch" : "main",
         "revision" : "543aa0122a0257b992f6c7d62d18a26e3dffb8fe"

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "AppleAPI", targets: ["AppleAPI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.1.4")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.5.0")),
         .package(url: "https://github.com/mxcl/Path.swift.git", .upToNextMinor(from: "0.16.0")),
         .package(url: "https://github.com/mxcl/Version.git", .upToNextMinor(from: "1.0.3")),
         .package(url: "https://github.com/mxcl/PromiseKit.git", .upToNextMinor(from: "6.22.1")),
@@ -40,10 +40,10 @@ let package = Package(
         .target(
             name: "XcodesKit",
             dependencies: [
-                "AppleAPI", 
+                "AppleAPI",
                 "KeychainAccess",
                 "LegibleError",
-                .product(name: "Path", package: "Path.swift"), 
+                .product(name: "Path", package: "Path.swift"),
                 "PromiseKit",
                 .product(name: "PMKFoundation", package: "Foundation"),
                 "SwiftSoup",


### PR DESCRIPTION
Xcodes is relying on a fairly old version of the swift-argument-parser, causing package resolution issues in CLI tools integrating Xcodes using new versions.

Closes https://github.com/XcodesOrg/xcodes/pull/354