### PR TITLE
support multiple architectures for runtimes

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcodes.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcodes.xcscheme
@@ -128,8 +128,12 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "runtimes install &quot;visionOS 1.0-beta1&quot;"
+            argument = "runtimes install &quot;visionOS 26.0-beta3 arm64&quot;"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "runtimes --include-betas"
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "install --help"

--- a/Sources/XcodesKit/Models+Runtimes.swift
+++ b/Sources/XcodesKit/Models+Runtimes.swift
@@ -12,6 +12,7 @@ public struct DownloadableRuntime: Decodable {
     let category: Category
     let simulatorVersion: SimulatorVersion
     let source: String?
+    let architectures: [String]?
     let dictionaryVersion: Int
     let contentType: ContentType
     let platform: Platform
@@ -23,7 +24,7 @@ public struct DownloadableRuntime: Decodable {
     let authentication: Authentication?
 
     var betaNumber: Int? {
-        enum Regex { static let shared = try! NSRegularExpression(pattern: "b[0-9]+$") }
+        enum Regex { static let shared = try! NSRegularExpression(pattern: "b[0-9]+") }
         guard var foundString = Regex.shared.firstString(in: identifier) else { return nil }
         foundString.removeFirst()
         return Int(foundString)!
@@ -34,7 +35,7 @@ public struct DownloadableRuntime: Decodable {
     }
 
     var visibleIdentifier: String {
-        return platform.shortName + " " + completeVersion
+        return platform.shortName + " " + completeVersion + (architectures != nil ? " \(architectures?.joined(separator: "|") ?? "")" : "")
     }
 }
 
@@ -53,6 +54,7 @@ struct SDKToSimulatorMapping: Decodable {
     let sdkBuildUpdate: String
     let simulatorBuildUpdate: String
     let sdkIdentifier: String
+    let downloadableIdentifiers: [String]?
 }
 
 extension DownloadableRuntime {

--- a/Sources/XcodesKit/RuntimeInstaller.swift
+++ b/Sources/XcodesKit/RuntimeInstaller.swift
@@ -28,13 +28,15 @@ public class RuntimeInstaller {
                                                            betaNumber: downloadable.betaNumber,
                                                            version: downloadable.simulatorVersion.version,
                                                            build: downloadable.simulatorVersion.buildUpdate,
-                                                           kind: $0.kind))
+                                                           kind: $0.kind,
+                                                           architectures: downloadable.architectures))
                 }
             } else {
                 mappedRuntimes.append(PrintableRuntime(platform: downloadable.platform,
                                                        betaNumber: downloadable.betaNumber,
                                                        version: downloadable.simulatorVersion.version,
-                                                       build: downloadable.simulatorVersion.buildUpdate))
+                                                       build: downloadable.simulatorVersion.buildUpdate,
+                                                       architectures: downloadable.architectures))
             }
         }
 
@@ -47,7 +49,8 @@ public class RuntimeInstaller {
                                           betaNumber: resolvedBetaNumber,
                                           version: runtime.version,
                                           build: runtime.build,
-                                          kind: runtime.kind)
+                                          kind: runtime.kind,
+                                          architectures: nil)
 
             mappedRuntimes.indices {
                 result.visibleIdentifier == $0.visibleIdentifier
@@ -361,7 +364,7 @@ extension RuntimeInstaller {
         public var errorDescription: String? {
             switch self {
                 case let .unavailableRuntime(version):
-                    return "Runtime \(version) is invalid or not downloadable"
+                    return "Runtime \(version) is invalid or not downloadable. Please include arm64 or x86_64 in the version string if shown."
                 case .failedMountingDMG:
                     return "Failed to mount image."
                 case .rootNeeded:
@@ -384,13 +387,14 @@ fileprivate struct PrintableRuntime {
     let build: String
     var kind: InstalledRuntime.Kind? = nil
     var hasDuplicateVersion = false
+    let architectures: [String]?
 
     var completeVersion: String {
         makeVersion(for: version, betaNumber: betaNumber)
     }
 
     var visibleIdentifier: String {
-        return platform.shortName + " " + completeVersion
+        return platform.shortName + " " + completeVersion + (architectures != nil ? " \(architectures?.joined(separator: "|") ?? "")" : "")
     }
 }
 


### PR DESCRIPTION
Starting in Xcode 26 beta 2, Apple is now returning different runtime builds for different architectures.

### Before
```
xcodes runtimes --include-betas

iOS 18.5 (Installed)
iOS 26.0-beta1 (Installed)
iOS 26.0-beta1 (Installed)
iOS 26.0-beta2
iOS 26.0-beta3
iOS 26.0
iOS 26.0
```
### After
```
xcodes runtimes --include-betas

iOS 18.5  (Installed)
iOS 26.0-beta1 arm64|x86_64 (Installed)
iOS 26.0-beta1 arm64|x86_64 (Installed)
iOS 26.0-beta2 arm64|x86_64
iOS 26.0-beta2 arm64
iOS 26.0-beta3 arm64|x86_64
iOS 26.0-beta3 arm64
```

to fully install now, users will have to use `iOS 26.0-beta3 arm64|x86_64` as the full identifier to distinguish the id as both have the same build version. 

Installing via build version will still work but (I believe) will grab the universal variant. 

NOTE: In this PR `xcodes runtimes install "iOS 26.0-beta3 arm64"` won't actually install the Apple Silicon variant. Need to add in support for `-architectureVariant <universal|arm64>` for the `xcodebuild` on Xcode 26 beta - logged in https://github.com/XcodesOrg/xcodes/issues/436
