### PR TITLE
Add support for Xcode 26 Beta 5

### DIFF
--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -183,7 +183,7 @@ extension XcodeList {
             let xcodesWithSameBuildMetadataIdentifiers = xcodes
                 .filter({ $0.version.buildMetadataIdentifiers == xcode.version.buildMetadataIdentifiers })
             if xcodesWithSameBuildMetadataIdentifiers.count > 1,
-               xcode.version.prereleaseIdentifiers.isEmpty || xcode.version.prereleaseIdentifiers == ["GM"] {
+               xcode.version.prereleaseIdentifiers.isEmpty || xcode.version.prereleaseIdentifiers == ["GM"] || xcode.version.prereleaseIdentifiers.contains("Beta") {
                 filteredXcodes.append(xcode)
             } else if xcodesWithSameBuildMetadataIdentifiers.count == 1 {
                 filteredXcodes.append(xcode)


### PR DESCRIPTION
Fixes #439. This PR improves the App Store version sorting logic to handle versions more accurately based on semantic ordering.