### PR TITLE
README: Point user to `homebrew-core`, not the `xcodesorg/made` tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Xcodes is now part of the `XcodesOrg` - [read more here](nextstep.md)
 ### Homebrew (Preferred)
 
 ```sh
-brew install xcodesorg/made/xcodes
+brew install xcodes
 ```
 
 These are Developer ID-signed and notarized release builds and don't require Xcode to already be installed in order to use.


### PR DESCRIPTION
On the machine I tried (macOS Tahoe on Apple Silicon), bottles are not available with the [`xcodesorg/made` tap](https://github.com/XcodesOrg/homebrew-made), but they are available when using [`homebrew/core`](https://github.com/Homebrew/homebrew-core/blob/main/Formula/x/xcodes.rb).

This PR updates the README to point the users to the latter.

An alternative solution would be make bottles available in the `xcodesorg/made` tap (https://github.com/XcodesOrg/homebrew-made/issues/3).