### PR TITLE
feat(install): architecture-specific Xcode installs with safe force-reinstall rollback

### DIFF
--- a/Sources/XcodesKit/XcodeDistributionArchitecture.swift
+++ b/Sources/XcodesKit/XcodeDistributionArchitecture.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// `XcodeDistributionArchitecture` describes a CPU architecture advertised by
+/// an Xcode download entry from xcodereleases metadata.
+/// Raw values are normalized lowercase identifiers used by the upstream data.
+/// Only known architectures are representable (`arm64`, `x86_64`).
+/// `rawValue` is stable and suitable for persistence/comparison.
+public enum XcodeDistributionArchitecture: String, CaseIterable, Codable, Hashable {
+    case arm64
+    case x86_64
+}

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -218,10 +218,16 @@ public final class XcodeInstaller {
                                         forceReinstall: forceReinstall)
         }
         .then { xcode, url -> Promise<InstalledXcode> in
-            if forceReinstall {
-                try self.removeExistingInstalledAppIfNeeded(version: xcode.version, destination: destination)
+            self.installArchivedXcodeWithForceReinstallRollbackIfNeeded(forceReinstall: forceReinstall,
+                                                                        version: xcode.version,
+                                                                        destination: destination) {
+                self.installArchivedXcode(xcode,
+                                          at: url,
+                                          to: destination,
+                                          experimentalUnxip: experimentalUnxip,
+                                          emptyTrash: emptyTrash,
+                                          noSuperuser: noSuperuser)
             }
-            return self.installArchivedXcode(xcode, at: url, to: destination, experimentalUnxip: experimentalUnxip, emptyTrash: emptyTrash, noSuperuser: noSuperuser)
         }
         .recover { error -> Promise<InstalledXcode> in
             switch error {
@@ -445,6 +451,7 @@ public final class XcodeInstaller {
                 Current.logging.log("\(InstallationStep.downloading(version: xcode.version.description, progress: nil, willInstall: willInstall))")
             }
             let formatter = NumberFormatter(numberStyle: .percent)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
             var observation: NSKeyValueObservation?
 
             let promise = self.downloadOrUseExistingArchive(for: xcode, downloader: downloader, willInstall: willInstall, progressChanged: { progress in
@@ -519,12 +526,76 @@ public final class XcodeInstaller {
         architectures.map(\.rawValue).sorted().joined(separator: ", ")
     }
 
-    private func removeExistingInstalledAppIfNeeded(version: Version, destination: Path) throws {
-        let installedAppPath = destination.join("Xcode-\(version.descriptionWithoutBuildMetadata).app")
-        guard Current.files.fileExists(atPath: installedAppPath.string) else { return }
+    private struct ForceReinstallBackup {
+        let installedAppPath: Path
+        let backupPath: Path
+    }
 
-        Current.logging.log("Removing existing Xcode at \(installedAppPath.string) due to --force-reinstall.")
-        try Current.files.trashItem(at: installedAppPath.url)
+    private func installArchivedXcodeWithForceReinstallRollbackIfNeeded(forceReinstall: Bool,
+                                                                        version: Version,
+                                                                        destination: Path,
+                                                                        installOperation: @escaping () -> Promise<InstalledXcode>) -> Promise<InstalledXcode> {
+        guard forceReinstall else { return installOperation() }
+
+        do {
+            let backup = try makeForceReinstallBackupIfNeeded(version: version, destination: destination)
+            return installOperation()
+                .get { _ in
+                    self.cleanUpForceReinstallBackupAfterSuccessIfNeeded(backup)
+                }
+                .recover { error -> Promise<InstalledXcode> in
+                    try self.restoreForceReinstallBackupAfterFailureIfNeeded(backup)
+                    throw error
+                }
+        } catch {
+            return Promise(error: error)
+        }
+    }
+
+    private static func installedAppPath(for version: Version, in destination: Path) -> Path {
+        destination.join("Xcode-\(version.descriptionWithoutBuildMetadata).app")
+    }
+
+    private static func forceReinstallBackupPath(for installedAppPath: Path) -> Path {
+        installedAppPath.parent.join("\(installedAppPath.basename()).xcodes-force-reinstall-\(UUID().uuidString)")
+    }
+
+    private func makeForceReinstallBackupIfNeeded(version: Version, destination: Path) throws -> ForceReinstallBackup? {
+        let installedAppPath = Self.installedAppPath(for: version, in: destination)
+        guard Current.files.fileExists(atPath: installedAppPath.string) else { return nil }
+
+        var backupPath = Self.forceReinstallBackupPath(for: installedAppPath)
+        while Current.files.fileExists(atPath: backupPath.string) {
+            backupPath = Self.forceReinstallBackupPath(for: installedAppPath)
+        }
+
+        Current.logging.log("Temporarily moving existing Xcode at \(installedAppPath.string) to \(backupPath.string) due to --force-reinstall.")
+        try Current.files.moveItem(at: installedAppPath.url, to: backupPath.url)
+
+        return ForceReinstallBackup(installedAppPath: installedAppPath, backupPath: backupPath)
+    }
+
+    private func restoreForceReinstallBackupAfterFailureIfNeeded(_ backup: ForceReinstallBackup?) throws {
+        guard let backup else { return }
+        guard Current.files.fileExists(atPath: backup.backupPath.string) else { return }
+
+        if Current.files.fileExists(atPath: backup.installedAppPath.string) {
+            try Current.files.removeItem(at: backup.installedAppPath.url)
+        }
+
+        Current.logging.log("Restoring previous Xcode at \(backup.installedAppPath.string) after failed --force-reinstall attempt.")
+        try Current.files.moveItem(at: backup.backupPath.url, to: backup.installedAppPath.url)
+    }
+
+    private func cleanUpForceReinstallBackupAfterSuccessIfNeeded(_ backup: ForceReinstallBackup?) {
+        guard let backup else { return }
+        guard Current.files.fileExists(atPath: backup.backupPath.string) else { return }
+
+        do {
+            _ = try Current.files.trashItem(at: backup.backupPath.url)
+        } catch {
+            Current.logging.log("Warning: failed to clean up temporary --force-reinstall backup at \(backup.backupPath.string): \(error.localizedDescription)".yellow)
+        }
     }
 
     public func downloadOrUseExistingArchive(for xcode: Xcode, downloader: Downloader, willInstall: Bool, progressChanged: @escaping (Progress) -> Void) -> Promise<URL> {

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -160,7 +160,7 @@ public final class XcodeInstaller {
 
     public enum InstallationType {
         case version(String)
-        case versionWithArchitectures(String, [String])
+        case versionWithArchitectures(String, Set<XcodeDistributionArchitecture>)
         case path(String, Path)
         case latest
         case latestPrerelease
@@ -301,7 +301,7 @@ public final class XcodeInstaller {
                                dataSource: DataSource,
                                downloader: Downloader,
                                willInstall: Bool,
-                               requiredArchitectures: [String]?) -> Promise<(Xcode, URL)> {
+                               requiredArchitectures: Set<XcodeDistributionArchitecture>?) -> Promise<(Xcode, URL)> {
         return firstly { () -> Promise<Void> in
             switch dataSource {
             case .apple:
@@ -383,15 +383,14 @@ public final class XcodeInstaller {
     }
 
     static func selectXcodeCandidate(version: Version,
-                                     requiredArchitectures: [String]?,
+                                     requiredArchitectures: Set<XcodeDistributionArchitecture>?,
                                      availableXcodes: [Xcode],
-                                     architecturesByDownloadPath: [String: [String]]) -> Xcode? {
+                                     architecturesByDownloadPath: [String: Set<XcodeDistributionArchitecture>]) -> Xcode? {
         guard let requiredArchitectures else {
             return availableXcodes.first(withVersion: version)
         }
 
-        let requiredArchitectureKey = normalizedArchitectureKey(requiredArchitectures)
-        guard !requiredArchitectureKey.isEmpty else {
+        guard !requiredArchitectures.isEmpty else {
             return availableXcodes.first(withVersion: version)
         }
 
@@ -400,7 +399,7 @@ public final class XcodeInstaller {
                   let candidateArchitectures = architecturesByDownloadPath[candidate.downloadPath] else {
                 return false
             }
-            return normalizedArchitectureKey(candidateArchitectures) == requiredArchitectureKey
+            return candidateArchitectures == requiredArchitectures
         }
 
         if let exactVersionMatch = candidates.first(where: { $0.version == version }) {
@@ -409,11 +408,6 @@ public final class XcodeInstaller {
 
         return candidates.first
     }
-
-    private static func normalizedArchitectureKey(_ architectures: [String]) -> [String] {
-        return Array(Set(architectures.map { $0.lowercased() })).sorted()
-    }
-
     public func downloadOrUseExistingArchive(for xcode: Xcode, downloader: Downloader, willInstall: Bool, progressChanged: @escaping (Progress) -> Void) -> Promise<URL> {
         // Check to see if the archive is in the expected path in case it was downloaded but failed to install
         let expectedArchivePath = Path.xcodesApplicationSupport/"Xcode-\(xcode.version).\(xcode.filename.suffix(fromLast: "."))"

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -21,9 +21,11 @@ public final class XcodeInstaller {
         case unsupportedFileFormat(extension: String)
         case missingSudoerPassword
         case unavailableVersion(Version)
+        case unavailableVersionForArchitectures(version: Version, requiredArchitectures: Set<XcodeDistributionArchitecture>)
         case noReleaseVersionAvailable
         case noPrereleaseVersionAvailable
         case versionAlreadyInstalled(InstalledXcode)
+        case architectureInstallationRequiresForceReinstall(installedXcode: InstalledXcode, requiredArchitectures: Set<XcodeDistributionArchitecture>)
         case invalidVersion(String)
         case versionNotInstalled(Version)
         case unauthorized
@@ -61,12 +63,19 @@ public final class XcodeInstaller {
                 return "Missing password. Please try again."
             case let .unavailableVersion(version):
                 return "Could not find version \(version.appleDescription)."
+            case let .unavailableVersionForArchitectures(version, requiredArchitectures):
+                return "Could not find version \(version.appleDescription) with architectures \(XcodeInstaller.architecturesDescription(requiredArchitectures))."
             case .noReleaseVersionAvailable:
                 return "No release versions available."
             case .noPrereleaseVersionAvailable:
                 return "No prerelease versions available."
             case let .versionAlreadyInstalled(installedXcode):
                 return "\(installedXcode.version.appleDescription) is already installed at \(installedXcode.path)"
+            case let .architectureInstallationRequiresForceReinstall(installedXcode, requiredArchitectures):
+                return """
+                       \(installedXcode.version.appleDescription) is already installed at \(installedXcode.path).
+                       Reinstalling a specific architecture variant (\(XcodeInstaller.architecturesDescription(requiredArchitectures))) requires --force-reinstall.
+                       """
             case let .invalidVersion(version):
                 return "\(version) is not a valid version number."
             case let .versionNotInstalled(version):
@@ -166,9 +175,24 @@ public final class XcodeInstaller {
         case latestPrerelease
     }
 
-    public func install(_ installationType: InstallationType, dataSource: DataSource, downloader: Downloader, destination: Path, experimentalUnxip: Bool = false, emptyTrash: Bool, noSuperuser: Bool) -> Promise<InstalledXcode> {
+    public func install(_ installationType: InstallationType,
+                        dataSource: DataSource,
+                        downloader: Downloader,
+                        destination: Path,
+                        experimentalUnxip: Bool = false,
+                        emptyTrash: Bool,
+                        noSuperuser: Bool,
+                        forceReinstall: Bool = false) -> Promise<InstalledXcode> {
         return firstly { () -> Promise<InstalledXcode> in
-            return self.install(installationType, dataSource: dataSource, downloader: downloader, destination: destination, attemptNumber: 0, experimentalUnxip: experimentalUnxip, emptyTrash: emptyTrash, noSuperuser: noSuperuser)
+            return self.install(installationType,
+                                dataSource: dataSource,
+                                downloader: downloader,
+                                destination: destination,
+                                attemptNumber: 0,
+                                experimentalUnxip: experimentalUnxip,
+                                emptyTrash: emptyTrash,
+                                noSuperuser: noSuperuser,
+                                forceReinstall: forceReinstall)
         }
         .map { xcode in
             Current.logging.log("\nXcode \(xcode.version.descriptionWithoutBuildMetadata) has been installed to \(xcode.path.string)".green)
@@ -176,11 +200,27 @@ public final class XcodeInstaller {
         }
     }
 
-    private func install(_ installationType: InstallationType, dataSource: DataSource, downloader: Downloader, destination: Path, attemptNumber: Int, experimentalUnxip: Bool, emptyTrash: Bool, noSuperuser: Bool) -> Promise<InstalledXcode> {
+    private func install(_ installationType: InstallationType,
+                         dataSource: DataSource,
+                         downloader: Downloader,
+                         destination: Path,
+                         attemptNumber: Int,
+                         experimentalUnxip: Bool,
+                         emptyTrash: Bool,
+                         noSuperuser: Bool,
+                         forceReinstall: Bool) -> Promise<InstalledXcode> {
         return firstly { () -> Promise<(Xcode, URL)> in
-            return self.getXcodeArchive(installationType, dataSource: dataSource, downloader: downloader, destination: destination, willInstall: true)
+            return self.getXcodeArchive(installationType,
+                                        dataSource: dataSource,
+                                        downloader: downloader,
+                                        destination: destination,
+                                        willInstall: true,
+                                        forceReinstall: forceReinstall)
         }
         .then { xcode, url -> Promise<InstalledXcode> in
+            if forceReinstall {
+                try self.removeExistingInstalledAppIfNeeded(version: xcode.version, destination: destination)
+            }
             return self.installArchivedXcode(xcode, at: url, to: destination, experimentalUnxip: experimentalUnxip, emptyTrash: emptyTrash, noSuperuser: noSuperuser)
         }
         .recover { error -> Promise<InstalledXcode> in
@@ -198,7 +238,15 @@ public final class XcodeInstaller {
                         Current.logging.log(error.legibleLocalizedDescription.red)
                         Current.logging.log("Removing damaged XIP and re-attempting installation.\n")
                         try Current.files.removeItem(at: damagedXIPURL)
-                        return self.install(installationType, dataSource: dataSource, downloader: downloader, destination: destination, attemptNumber: attemptNumber + 1, experimentalUnxip: experimentalUnxip, emptyTrash: emptyTrash, noSuperuser: noSuperuser)
+                        return self.install(installationType,
+                                            dataSource: dataSource,
+                                            downloader: downloader,
+                                            destination: destination,
+                                            attemptNumber: attemptNumber + 1,
+                                            experimentalUnxip: experimentalUnxip,
+                                            emptyTrash: emptyTrash,
+                                            noSuperuser: noSuperuser,
+                                            forceReinstall: forceReinstall)
                     }
                 }
             default:
@@ -222,7 +270,12 @@ public final class XcodeInstaller {
         }
     }
 
-    private func getXcodeArchive(_ installationType: InstallationType, dataSource: DataSource, downloader: Downloader, destination: Path, willInstall: Bool) -> Promise<(Xcode, URL)> {
+    private func getXcodeArchive(_ installationType: InstallationType,
+                                 dataSource: DataSource,
+                                 downloader: Downloader,
+                                 destination: Path,
+                                 willInstall: Bool,
+                                 forceReinstall: Bool = false) -> Promise<(Xcode, URL)> {
         return firstly { () -> Promise<(Xcode, URL)> in
             switch installationType {
             case .latest:
@@ -236,8 +289,13 @@ public final class XcodeInstaller {
 
                         Current.logging.log("Latest release version available is \(latestReleaseXcode.version.appleDescription)")
 
-                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestReleaseXcode.version) }) {
-                            throw Error.versionAlreadyInstalled(installedXcode)
+                        let installedXcode = willInstall
+                            ? Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestReleaseXcode.version) })
+                            : nil
+                        if let conflict = Self.installedVersionConflict(installedXcode: installedXcode,
+                                                                        requiredArchitectures: nil,
+                                                                        forceReinstall: forceReinstall) {
+                            throw conflict
                         }
 
                         return self.downloadXcode(version: latestReleaseXcode.version,
@@ -261,8 +319,13 @@ public final class XcodeInstaller {
                         }
                         Current.logging.log("Latest prerelease version available is \(latestPrereleaseXcode.version.appleDescription)")
 
-                        if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestPrereleaseXcode.version) }) {
-                            throw Error.versionAlreadyInstalled(installedXcode)
+                        let installedXcode = willInstall
+                            ? Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestPrereleaseXcode.version) })
+                            : nil
+                        if let conflict = Self.installedVersionConflict(installedXcode: installedXcode,
+                                                                        requiredArchitectures: nil,
+                                                                        forceReinstall: forceReinstall) {
+                            throw conflict
                         }
 
                         return self.downloadXcode(version: latestPrereleaseXcode.version,
@@ -275,22 +338,40 @@ public final class XcodeInstaller {
                 guard let version = Version(xcodeVersion: versionString) ?? Version.fromXcodeVersionFile() else {
                     throw Error.invalidVersion(versionString)
                 }
+                let installedXcode = willInstall
+                    ? Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) })
+                    : nil
+                if let conflict = Self.installedVersionConflict(installedXcode: installedXcode,
+                                                                requiredArchitectures: nil,
+                                                                forceReinstall: forceReinstall) {
+                    throw conflict
+                }
                 let xcode = Xcode(version: version, url: path.url, filename: String(path.string.suffix(fromLast: "/")), releaseDate: nil)
                 return Promise.value((xcode, path.url))
             case .version(let versionString):
                 guard let version = Version(xcodeVersion: versionString) ?? Version.fromXcodeVersionFile() else {
                     throw Error.invalidVersion(versionString)
                 }
-                if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) }) {
-                    throw Error.versionAlreadyInstalled(installedXcode)
+                let installedXcode = willInstall
+                    ? Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) })
+                    : nil
+                if let conflict = Self.installedVersionConflict(installedXcode: installedXcode,
+                                                                requiredArchitectures: nil,
+                                                                forceReinstall: forceReinstall) {
+                    throw conflict
                 }
                 return self.downloadXcode(version: version, dataSource: dataSource, downloader: downloader, willInstall: willInstall, requiredArchitectures: nil)
             case .versionWithArchitectures(let versionString, let requiredArchitectures):
                 guard let version = Version(xcodeVersion: versionString) ?? Version.fromXcodeVersionFile() else {
                     throw Error.invalidVersion(versionString)
                 }
-                if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) }) {
-                    throw Error.versionAlreadyInstalled(installedXcode)
+                let installedXcode = willInstall
+                    ? Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) })
+                    : nil
+                if let conflict = Self.installedVersionConflict(installedXcode: installedXcode,
+                                                                requiredArchitectures: requiredArchitectures,
+                                                                forceReinstall: forceReinstall) {
+                    throw conflict
                 }
                 return self.downloadXcode(version: version, dataSource: dataSource, downloader: downloader, willInstall: willInstall, requiredArchitectures: requiredArchitectures)
             }
@@ -333,7 +414,7 @@ public final class XcodeInstaller {
                                                         requiredArchitectures: requiredArchitectures,
                                                         availableXcodes: self.xcodeList.availableXcodes,
                                                         architecturesByDownloadPath: self.xcodeList.xcodeArchitecturesByDownloadPath) else {
-                throw Error.unavailableVersion(version)
+                throw Self.unavailableXcodeError(version: version, requiredArchitectures: requiredArchitectures)
             }
 
             return Promise.value(xcode)
@@ -408,6 +489,44 @@ public final class XcodeInstaller {
 
         return candidates.first
     }
+
+    static func installedVersionConflict(installedXcode: InstalledXcode?,
+                                         requiredArchitectures: Set<XcodeDistributionArchitecture>?,
+                                         forceReinstall: Bool) -> Error? {
+        guard let installedXcode else { return nil }
+        guard !forceReinstall else { return nil }
+
+        if let requiredArchitectures {
+            return .architectureInstallationRequiresForceReinstall(
+                installedXcode: installedXcode,
+                requiredArchitectures: requiredArchitectures
+            )
+        }
+
+        return .versionAlreadyInstalled(installedXcode)
+    }
+
+    static func unavailableXcodeError(version: Version,
+                                      requiredArchitectures: Set<XcodeDistributionArchitecture>?) -> Error {
+        guard let requiredArchitectures, !requiredArchitectures.isEmpty else {
+            return .unavailableVersion(version)
+        }
+        return .unavailableVersionForArchitectures(version: version,
+                                                   requiredArchitectures: requiredArchitectures)
+    }
+
+    static func architecturesDescription(_ architectures: Set<XcodeDistributionArchitecture>) -> String {
+        architectures.map(\.rawValue).sorted().joined(separator: ", ")
+    }
+
+    private func removeExistingInstalledAppIfNeeded(version: Version, destination: Path) throws {
+        let installedAppPath = destination.join("Xcode-\(version.descriptionWithoutBuildMetadata).app")
+        guard Current.files.fileExists(atPath: installedAppPath.string) else { return }
+
+        Current.logging.log("Removing existing Xcode at \(installedAppPath.string) due to --force-reinstall.")
+        try Current.files.trashItem(at: installedAppPath.url)
+    }
+
     public func downloadOrUseExistingArchive(for xcode: Xcode, downloader: Downloader, willInstall: Bool, progressChanged: @escaping (Progress) -> Void) -> Promise<URL> {
         // Check to see if the archive is in the expected path in case it was downloaded but failed to install
         let expectedArchivePath = Path.xcodesApplicationSupport/"Xcode-\(xcode.version).\(xcode.filename.suffix(fromLast: "."))"

--- a/Sources/XcodesKit/XcodeInstaller.swift
+++ b/Sources/XcodesKit/XcodeInstaller.swift
@@ -160,6 +160,7 @@ public final class XcodeInstaller {
 
     public enum InstallationType {
         case version(String)
+        case versionWithArchitectures(String, [String])
         case path(String, Path)
         case latest
         case latestPrerelease
@@ -234,12 +235,16 @@ public final class XcodeInstaller {
                         }
 
                         Current.logging.log("Latest release version available is \(latestReleaseXcode.version.appleDescription)")
-                        
+
                         if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: latestReleaseXcode.version) }) {
                             throw Error.versionAlreadyInstalled(installedXcode)
                         }
 
-                        return self.downloadXcode(version: latestReleaseXcode.version, dataSource: dataSource, downloader: downloader, willInstall: willInstall)
+                        return self.downloadXcode(version: latestReleaseXcode.version,
+                                                  dataSource: dataSource,
+                                                  downloader: downloader,
+                                                  willInstall: willInstall,
+                                                  requiredArchitectures: nil)
                     }
             case .latestPrerelease:
                 Current.logging.log("Updating...")
@@ -260,7 +265,11 @@ public final class XcodeInstaller {
                             throw Error.versionAlreadyInstalled(installedXcode)
                         }
 
-                        return self.downloadXcode(version: latestPrereleaseXcode.version, dataSource: dataSource, downloader: downloader, willInstall: willInstall)
+                        return self.downloadXcode(version: latestPrereleaseXcode.version,
+                                                  dataSource: dataSource,
+                                                  downloader: downloader,
+                                                  willInstall: willInstall,
+                                                  requiredArchitectures: nil)
                     }
             case .path(let versionString, let path):
                 guard let version = Version(xcodeVersion: versionString) ?? Version.fromXcodeVersionFile() else {
@@ -275,12 +284,24 @@ public final class XcodeInstaller {
                 if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) }) {
                     throw Error.versionAlreadyInstalled(installedXcode)
                 }
-                return self.downloadXcode(version: version, dataSource: dataSource, downloader: downloader, willInstall: willInstall)
+                return self.downloadXcode(version: version, dataSource: dataSource, downloader: downloader, willInstall: willInstall, requiredArchitectures: nil)
+            case .versionWithArchitectures(let versionString, let requiredArchitectures):
+                guard let version = Version(xcodeVersion: versionString) ?? Version.fromXcodeVersionFile() else {
+                    throw Error.invalidVersion(versionString)
+                }
+                if willInstall, let installedXcode = Current.files.installedXcodes(destination).first(where: { $0.version.isEquivalent(to: version) }) {
+                    throw Error.versionAlreadyInstalled(installedXcode)
+                }
+                return self.downloadXcode(version: version, dataSource: dataSource, downloader: downloader, willInstall: willInstall, requiredArchitectures: requiredArchitectures)
             }
         }
     }
 
-    private func downloadXcode(version: Version, dataSource: DataSource, downloader: Downloader, willInstall: Bool) -> Promise<(Xcode, URL)> {
+    private func downloadXcode(version: Version,
+                               dataSource: DataSource,
+                               downloader: Downloader,
+                               willInstall: Bool,
+                               requiredArchitectures: [String]?) -> Promise<(Xcode, URL)> {
         return firstly { () -> Promise<Void> in
             switch dataSource {
             case .apple:
@@ -298,14 +319,20 @@ public final class XcodeInstaller {
             }
         }
         .then { () -> Promise<Void> in
-            if self.xcodeList.shouldUpdateBeforeDownloading(version: version) {
+            let shouldRefreshForArchitectureSelection = requiredArchitectures != nil &&
+                dataSource == .xcodeReleases &&
+                self.xcodeList.xcodeArchitecturesByDownloadPath.isEmpty
+            if self.xcodeList.shouldUpdateBeforeDownloading(version: version) || shouldRefreshForArchitectureSelection {
                 return self.xcodeList.update(dataSource: dataSource).asVoid()
             } else {
                 return Promise()
             }
         }
         .then { () -> Promise<Xcode> in
-            guard let xcode = self.xcodeList.availableXcodes.first(withVersion: version) else {
+            guard let xcode = Self.selectXcodeCandidate(version: version,
+                                                        requiredArchitectures: requiredArchitectures,
+                                                        availableXcodes: self.xcodeList.availableXcodes,
+                                                        architecturesByDownloadPath: self.xcodeList.xcodeArchitecturesByDownloadPath) else {
                 throw Error.unavailableVersion(version)
             }
 
@@ -353,6 +380,38 @@ public final class XcodeInstaller {
                 .get { _ in observation?.invalidate() }
                 .map { return (xcode, $0) }
         }
+    }
+
+    static func selectXcodeCandidate(version: Version,
+                                     requiredArchitectures: [String]?,
+                                     availableXcodes: [Xcode],
+                                     architecturesByDownloadPath: [String: [String]]) -> Xcode? {
+        guard let requiredArchitectures else {
+            return availableXcodes.first(withVersion: version)
+        }
+
+        let requiredArchitectureKey = normalizedArchitectureKey(requiredArchitectures)
+        guard !requiredArchitectureKey.isEmpty else {
+            return availableXcodes.first(withVersion: version)
+        }
+
+        let candidates = availableXcodes.filter { candidate in
+            guard candidate.version.isEquivalent(to: version),
+                  let candidateArchitectures = architecturesByDownloadPath[candidate.downloadPath] else {
+                return false
+            }
+            return normalizedArchitectureKey(candidateArchitectures) == requiredArchitectureKey
+        }
+
+        if let exactVersionMatch = candidates.first(where: { $0.version == version }) {
+            return exactVersionMatch
+        }
+
+        return candidates.first
+    }
+
+    private static func normalizedArchitectureKey(_ architectures: [String]) -> [String] {
+        return Array(Set(architectures.map { $0.lowercased() })).sorted()
     }
 
     public func downloadOrUseExistingArchive(for xcode: Xcode, downloader: Downloader, willInstall: Bool, progressChanged: @escaping (Progress) -> Void) -> Promise<URL> {

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -18,7 +18,7 @@ public final class XcodeList {
         return availableXcodes.isEmpty || (cacheAge ?? 0) > Self.maxCacheAge
     }
 
-    private(set) var xcodeArchitecturesByDownloadPath = [String: [String]]()
+    private(set) var xcodeArchitecturesByDownloadPath = [String: Set<XcodeDistributionArchitecture>]()
 
     public func shouldUpdateBeforeDownloading(version: Version) -> Bool {
         return availableXcodes.first(withVersion: version) == nil
@@ -146,56 +146,53 @@ extension XcodeList {
             Current.network.dataTask(with: URLRequest(url: URL(string: "https://xcodereleases.com/data.json")!))
         }
         .map { (data, response) in
-            let architecturesByDownloadPath = try self.parseArchitecturesByDownloadPath(from: data)
-            let decoder = JSONDecoder()
-            let xcReleasesXcodes = try decoder.decode([XCModel.Xcode].self, from: data)
-            let xcodes = xcReleasesXcodes.compactMap { xcReleasesXcode -> Xcode? in
-                guard
-                    let downloadURL = xcReleasesXcode.links?.download?.url,
-                    let version = Version(xcReleasesXcode: xcReleasesXcode)
-                else { return nil }
-
-                let releaseDate = Calendar(identifier: .gregorian).date(from: DateComponents(
-                    year: xcReleasesXcode.date.year,
-                    month: xcReleasesXcode.date.month,
-                    day: xcReleasesXcode.date.day
-                ))
-
-                return Xcode(
-                    version: version,
-                    url: downloadURL,
-                    filename: String(downloadURL.path.suffix(fromLast: "/")),
-                    releaseDate: releaseDate
-                )
-            }
-            self.xcodeArchitecturesByDownloadPath = architecturesByDownloadPath
-            return xcodes
+            let parsedPayload = try self.parseXcodeReleasesPayload(from: data)
+            self.xcodeArchitecturesByDownloadPath = parsedPayload.architecturesByDownloadPath
+            return parsedPayload.xcodes
         }
         .map(filterPrereleasesThatMatchReleaseBuildMetadataIdentifiers)
     }
 
-    func parseArchitecturesByDownloadPath(from data: Data) throws -> [String: [String]] {
-        let metadata =
-            try JSONDecoder().decode([XcodeReleasesArchitectureMetadata].self, from: data)
-        var result = [String: [String]]()
-        for release in metadata {
-            guard let download = release.links?.download,
-                  let url = download.url,
-                  let architectures = normalizedArchitectures(download.architectures),
-                  !architectures.isEmpty else {
-                continue
+    func parseXcodeReleasesPayload(from data: Data) throws -> XcodeReleasesPayload {
+        let records = try JSONDecoder().decode([XcodeReleasesRecord].self, from: data)
+        var architecturesByDownloadPath = [String: Set<XcodeDistributionArchitecture>]()
+
+        let xcodes = records.compactMap { record -> Xcode? in
+            let xcReleasesXcode = record.xcode
+            guard
+                let downloadURL = xcReleasesXcode.links?.download?.url,
+                let version = Version(xcReleasesXcode: xcReleasesXcode)
+            else { return nil }
+
+            let releaseDate = Calendar(identifier: .gregorian).date(from: DateComponents(
+                year: xcReleasesXcode.date.year,
+                month: xcReleasesXcode.date.month,
+                day: xcReleasesXcode.date.day
+            ))
+
+            if let downloadArchitectures = record.downloadArchitectures {
+                architecturesByDownloadPath[downloadURL.path] = downloadArchitectures
             }
-            result[url.path] = architectures
+
+            return Xcode(
+                version: version,
+                url: downloadURL,
+                filename: String(downloadURL.path.suffix(fromLast: "/")),
+                releaseDate: releaseDate
+            )
         }
-        return result
+
+        return XcodeReleasesPayload(
+            xcodes: xcodes,
+            architecturesByDownloadPath: architecturesByDownloadPath
+        )
     }
 
-    func normalizedArchitectures(_ architectures: [String]?) -> [String]? {
+    static func normalizedArchitectures(_ architectures: [String]?) -> Set<XcodeDistributionArchitecture>? {
         guard let architectures else { return nil }
-        let supportedArchitectures = Set(["arm64", "x86_64"])
-        let normalized = Array(Set(architectures.map { $0.lowercased() }))
-            .filter { supportedArchitectures.contains($0) }
-            .sorted()
+        let normalized = Set(
+            architectures.compactMap { XcodeDistributionArchitecture(rawValue: $0.lowercased()) }
+        )
         return normalized.isEmpty ? nil : normalized
     }
 
@@ -224,15 +221,34 @@ extension XcodeList {
     }
 }
 
-private struct XcodeReleasesArchitectureMetadata: Decodable {
-    struct Links: Decodable {
-        struct Download: Decodable {
-            let url: URL?
-            let architectures: [String]?
-        }
+struct XcodeReleasesPayload {
+    let xcodes: [Xcode]
+    let architecturesByDownloadPath: [String: Set<XcodeDistributionArchitecture>]
+}
 
-        let download: Download?
+private struct XcodeReleasesRecord: Decodable {
+    let xcode: XCModel.Xcode
+    let downloadArchitectures: Set<XcodeDistributionArchitecture>?
+
+    enum CodingKeys: String, CodingKey {
+        case links
     }
 
-    let links: Links?
+    enum LinksCodingKeys: String, CodingKey {
+        case download
+    }
+
+    enum DownloadCodingKeys: String, CodingKey {
+        case architectures
+    }
+
+    init(from decoder: Decoder) throws {
+        xcode = try XCModel.Xcode(from: decoder)
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let linksContainer = try? container.nestedContainer(keyedBy: LinksCodingKeys.self, forKey: .links)
+        let downloadContainer = try? linksContainer?.nestedContainer(keyedBy: DownloadCodingKeys.self, forKey: .download)
+        let rawArchitectures = try downloadContainer?.decodeIfPresent([String].self, forKey: .architectures)
+        downloadArchitectures = XcodeList.normalizedArchitectures(rawArchitectures)
+    }
 }

--- a/Sources/XcodesKit/XcodeList.swift
+++ b/Sources/XcodesKit/XcodeList.swift
@@ -18,6 +18,8 @@ public final class XcodeList {
         return availableXcodes.isEmpty || (cacheAge ?? 0) > Self.maxCacheAge
     }
 
+    private(set) var xcodeArchitecturesByDownloadPath = [String: [String]]()
+
     public func shouldUpdateBeforeDownloading(version: Version) -> Bool {
         return availableXcodes.first(withVersion: version) == nil
     }
@@ -36,6 +38,7 @@ public final class XcodeList {
                     } + prereleaseXcodes
                     self.availableXcodes = xcodes
                     self.lastUpdated = Date()
+                    self.xcodeArchitecturesByDownloadPath = [:]
                     try? self.cacheAvailableXcodes(xcodes)
                     return xcodes
                 }
@@ -68,6 +71,7 @@ extension XcodeList {
 
         self.availableXcodes = xcodes
         self.lastUpdated = lastUpdated
+        self.xcodeArchitecturesByDownloadPath = [:]
     }
 
     private func cacheAvailableXcodes(_ xcodes: [Xcode]) throws {
@@ -94,7 +98,7 @@ extension XcodeList {
                 .filter { $0.name.range(of: "^Xcode [0-9]", options: .regularExpression) != nil }
                 .compactMap { download -> Xcode? in
                     let urlPrefix = URL(string: "https://download.developer.apple.com/")!
-                    guard 
+                    guard
                         let xcodeFile = download.files.first(where: { $0.remotePath.hasSuffix("dmg") || $0.remotePath.hasSuffix("xip") }),
                         let version = Version(xcodeVersion: download.name)
                     else { return nil }
@@ -119,7 +123,7 @@ extension XcodeList {
         let body = String(data: data, encoding: .utf8)!
         let document = try SwiftSoup.parse(body)
 
-        guard 
+        guard
             let xcodeHeader = try document.select("h2:containsOwn(Xcode)").first(),
             let productBuildVersion = try xcodeHeader.parent()?.select("li:contains(Build)").text().replacingOccurrences(of: "Build", with: ""),
             let releaseDateString = try xcodeHeader.parent()?.select("li:contains(Released)").text().replacingOccurrences(of: "Released", with: ""),
@@ -136,12 +140,13 @@ extension XcodeList {
 
 extension XcodeList {
     // MARK: - XcodeReleases
-    
+
     private func xcodeReleases() -> Promise<[Xcode]> {
         return firstly { () -> Promise<(data: Data, response: URLResponse)> in
             Current.network.dataTask(with: URLRequest(url: URL(string: "https://xcodereleases.com/data.json")!))
         }
         .map { (data, response) in
+            let architecturesByDownloadPath = try self.parseArchitecturesByDownloadPath(from: data)
             let decoder = JSONDecoder()
             let xcReleasesXcodes = try decoder.decode([XCModel.Xcode].self, from: data)
             let xcodes = xcReleasesXcodes.compactMap { xcReleasesXcode -> Xcode? in
@@ -149,13 +154,13 @@ extension XcodeList {
                     let downloadURL = xcReleasesXcode.links?.download?.url,
                     let version = Version(xcReleasesXcode: xcReleasesXcode)
                 else { return nil }
-                
+
                 let releaseDate = Calendar(identifier: .gregorian).date(from: DateComponents(
                     year: xcReleasesXcode.date.year,
                     month: xcReleasesXcode.date.month,
                     day: xcReleasesXcode.date.day
                 ))
-                
+
                 return Xcode(
                     version: version,
                     url: downloadURL,
@@ -163,11 +168,37 @@ extension XcodeList {
                     releaseDate: releaseDate
                 )
             }
+            self.xcodeArchitecturesByDownloadPath = architecturesByDownloadPath
             return xcodes
         }
         .map(filterPrereleasesThatMatchReleaseBuildMetadataIdentifiers)
     }
-    
+
+    func parseArchitecturesByDownloadPath(from data: Data) throws -> [String: [String]] {
+        let metadata =
+            try JSONDecoder().decode([XcodeReleasesArchitectureMetadata].self, from: data)
+        var result = [String: [String]]()
+        for release in metadata {
+            guard let download = release.links?.download,
+                  let url = download.url,
+                  let architectures = normalizedArchitectures(download.architectures),
+                  !architectures.isEmpty else {
+                continue
+            }
+            result[url.path] = architectures
+        }
+        return result
+    }
+
+    func normalizedArchitectures(_ architectures: [String]?) -> [String]? {
+        guard let architectures else { return nil }
+        let supportedArchitectures = Set(["arm64", "x86_64"])
+        let normalized = Array(Set(architectures.map { $0.lowercased() }))
+            .filter { supportedArchitectures.contains($0) }
+            .sorted()
+        return normalized.isEmpty ? nil : normalized
+    }
+
     /// Xcode Releases may have multiple releases with the same build metadata when a build doesn't change between candidate and final releases.
     /// For example, 12.3 RC and 12.3 are both build 12C33
     /// We don't care about that difference, so only keep the final release (GM or Release, in XCModel terms).
@@ -179,7 +210,7 @@ extension XcodeList {
                 filteredXcodes.append(xcode)
                 continue
             }
-            
+
             let xcodesWithSameBuildMetadataIdentifiers = xcodes
                 .filter({ $0.version.buildMetadataIdentifiers == xcode.version.buildMetadataIdentifiers })
             if xcodesWithSameBuildMetadataIdentifiers.count > 1,
@@ -190,5 +221,18 @@ extension XcodeList {
             }
         }
         return filteredXcodes
-    } 
+    }
+}
+
+private struct XcodeReleasesArchitectureMetadata: Decodable {
+    struct Links: Decodable {
+        struct Download: Decodable {
+            let url: URL?
+            let architectures: [String]?
+        }
+
+        let download: Download?
+    }
+
+    let links: Links?
 }

--- a/Sources/xcodes/App.swift
+++ b/Sources/xcodes/App.swift
@@ -51,6 +51,37 @@ struct GlobalColorOption: ParsableArguments {
     var color: Bool = true
 }
 
+enum InstallArchitectureOption: String, CaseIterable, ExpressibleByArgument {
+    case any
+    case appleSilicon = "apple-silicon"
+    case universal
+
+    var requiredArchitectures: [String]? {
+        switch self {
+        case .any:
+            return nil
+        case .appleSilicon:
+            return ["arm64"]
+        case .universal:
+            return ["arm64", "x86_64"]
+        }
+    }
+}
+
+enum InstallArchitectureOptionError: LocalizedError {
+    case requiresExplicitVersion
+    case unsupportedDataSource(DataSource)
+
+    var errorDescription: String? {
+        switch self {
+        case .requiresExplicitVersion:
+            return "--architecture is currently supported only when installing an explicit Xcode version."
+        case .unsupportedDataSource(let dataSource):
+            return "--architecture requires --data-source xcodeReleases, but got \(dataSource.rawValue)."
+        }
+    }
+}
+
 @main
 struct Xcodes: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
@@ -178,6 +209,7 @@ struct Xcodes: AsyncParsableCommand {
                           xcodes install 11 Beta 7
                           xcodes install 11.2 GM seed
                           xcodes install 9.0 --path ~/Archive/Xcode_9.xip
+                          xcodes install 26.0 --architecture apple-silicon --data-source xcodeReleases
                           xcodes install --latest-prerelease
                           xcodes install --latest --directory "/Volumes/Bag Of Holding/"
                         """
@@ -201,6 +233,11 @@ struct Xcodes: AsyncParsableCommand {
         @Option(help: "The path to an aria2 executable. Searches $PATH by default.",
                 completion: .file())
         var aria2: String?
+
+        @Option(
+            help: "Architecture variant for explicit version installs: any, apple-silicon, universal. Non-default values require --data-source xcodeReleases."
+        )
+        var architecture: InstallArchitectureOption = .any
 
         @Flag(help: "Don't use aria2 to download Xcode, even if its available.")
         var noAria2: Bool = false
@@ -245,26 +282,54 @@ struct Xcodes: AsyncParsableCommand {
 
             let versionString = version.joined(separator: " ")
 
-            let installation: XcodeInstaller.InstallationType
+            let baseInstallation: XcodeInstaller.InstallationType
             if latest {
-                installation = .latest
+                baseInstallation = .latest
             } else if latestPrerelease {
-                installation = .latestPrerelease
+                baseInstallation = .latestPrerelease
             } else if let pathString = pathString, let path = Path(pathString) {
-                installation = .path(versionString, path)
+                baseInstallation = .path(versionString, path)
             } else {
-                installation = .version(versionString)
+                baseInstallation = .version(versionString)
+            }
+
+            let installation: XcodeInstaller.InstallationType
+            if architecture == .any {
+                installation = baseInstallation
+            } else {
+                guard globalDataSource.dataSource == .xcodeReleases else {
+                    Install.exit(withLegibleError: InstallArchitectureOptionError.unsupportedDataSource(globalDataSource.dataSource))
+                }
+                guard case .version(let explicitVersion) = baseInstallation else {
+                    Install.exit(withLegibleError: InstallArchitectureOptionError.requiresExplicitVersion)
+                }
+                let requiredArchitectures = architecture.requiredArchitectures ?? []
+                installation = .versionWithArchitectures(explicitVersion, requiredArchitectures)
             }
             
             let downloader = noAria2 ? Downloader.urlSession : Downloader(aria2Path: aria2)
 
             let destination = getDirectory(possibleDirectory: directory)
 
-            if select, case .version(let version) = installation {
-                firstly {
-                    selectXcode(shouldPrint: print, pathOrVersion: version, directory: destination, fallbackToInteractive: false)
+            if select {
+                let selectedVersion: String?
+                switch installation {
+                case .version(let version):
+                    selectedVersion = version
+                case .versionWithArchitectures(let version, _):
+                    selectedVersion = version
+                default:
+                    selectedVersion = nil
                 }
-                .catch { _ in
+
+                if let selectedVersion {
+                    firstly {
+                        selectXcode(shouldPrint: print, pathOrVersion: selectedVersion, directory: destination, fallbackToInteractive: false)
+                    }
+                    .catch { _ in
+                        install(installation, using: downloader, to: destination)
+                    }
+                } else {
                     install(installation, using: downloader, to: destination)
                 }
             } else {
@@ -280,7 +345,15 @@ struct Xcodes: AsyncParsableCommand {
             firstly { () -> Promise<InstalledXcode> in
                 if useFastlaneAuth { fastlaneSessionManager.setupFastlaneAuth(fastlaneUser: fastlaneUser) }
                 // update the list before installing only for version type because the other types already update internally
-                if update, case .version = installation {
+                let shouldExplicitlyUpdate: Bool
+                switch installation {
+                case .version, .versionWithArchitectures:
+                    shouldExplicitlyUpdate = true
+                default:
+                    shouldExplicitlyUpdate = false
+                }
+
+                if update, shouldExplicitlyUpdate {
                     Current.logging.log("Updating...")
                     return xcodeList.update(dataSource: globalDataSource.dataSource)
                         .then { _ -> Promise<InstalledXcode> in

--- a/Sources/xcodes/App.swift
+++ b/Sources/xcodes/App.swift
@@ -315,25 +315,13 @@ struct Xcodes: AsyncParsableCommand {
 
             let destination = getDirectory(possibleDirectory: directory)
 
-            if select && shouldAttemptSelectionShortcut(installation: installation) {
-                let selectedVersion: String?
-                switch installation {
-                case .version(let version):
-                    selectedVersion = version
-                case .versionWithArchitectures(let version, _):
-                    selectedVersion = version
-                default:
-                    selectedVersion = nil
+            if select,
+               shouldAttemptSelectionShortcut(installation: installation),
+               case .version(let selectedVersion) = installation {
+                firstly {
+                    selectXcode(shouldPrint: print, pathOrVersion: selectedVersion, directory: destination, fallbackToInteractive: false)
                 }
-
-                if let selectedVersion {
-                    firstly {
-                        selectXcode(shouldPrint: print, pathOrVersion: selectedVersion, directory: destination, fallbackToInteractive: false)
-                    }
-                    .catch { _ in
-                        install(installation, using: downloader, to: destination)
-                    }
-                } else {
+                .catch { _ in
                     install(installation, using: downloader, to: destination)
                 }
             } else {

--- a/Sources/xcodes/App.swift
+++ b/Sources/xcodes/App.swift
@@ -210,6 +210,7 @@ struct Xcodes: AsyncParsableCommand {
                           xcodes install 11.2 GM seed
                           xcodes install 9.0 --path ~/Archive/Xcode_9.xip
                           xcodes install 26.0 --architecture apple-silicon --data-source xcodeReleases
+                          xcodes install 26.0 --architecture apple-silicon --force-reinstall --data-source xcodeReleases
                           xcodes install --latest-prerelease
                           xcodes install --latest --directory "/Volumes/Bag Of Holding/"
                         """
@@ -244,6 +245,9 @@ struct Xcodes: AsyncParsableCommand {
 
         @Flag(help: "Select the installed xcode version after installation.")
         var select: Bool = false
+
+        @Flag(help: "Reinstall even when the requested Xcode version is already installed.")
+        var forceReinstall: Bool = false
 
         @Flag(help: "Whether to update the list before installing")
         var update: Bool = false
@@ -311,7 +315,7 @@ struct Xcodes: AsyncParsableCommand {
 
             let destination = getDirectory(possibleDirectory: directory)
 
-            if select {
+            if select && shouldAttemptSelectionShortcut(installation: installation) {
                 let selectedVersion: String?
                 switch installation {
                 case .version(let version):
@@ -357,10 +361,24 @@ struct Xcodes: AsyncParsableCommand {
                     Current.logging.log("Updating...")
                     return xcodeList.update(dataSource: globalDataSource.dataSource)
                         .then { _ -> Promise<InstalledXcode> in
-                            xcodeInstaller.install(installation, dataSource: globalDataSource.dataSource, downloader: downloader, destination: destination, experimentalUnxip: experimentalUnxip, emptyTrash: emptyTrash, noSuperuser: noSuperuser)
+                            xcodeInstaller.install(installation,
+                                                   dataSource: globalDataSource.dataSource,
+                                                   downloader: downloader,
+                                                   destination: destination,
+                                                   experimentalUnxip: experimentalUnxip,
+                                                   emptyTrash: emptyTrash,
+                                                   noSuperuser: noSuperuser,
+                                                   forceReinstall: forceReinstall)
                         }
                 } else {
-                    return xcodeInstaller.install(installation, dataSource: globalDataSource.dataSource, downloader: downloader, destination: destination, experimentalUnxip: experimentalUnxip, emptyTrash: emptyTrash, noSuperuser: noSuperuser)
+                    return xcodeInstaller.install(installation,
+                                                  dataSource: globalDataSource.dataSource,
+                                                  downloader: downloader,
+                                                  destination: destination,
+                                                  experimentalUnxip: experimentalUnxip,
+                                                  emptyTrash: emptyTrash,
+                                                  noSuperuser: noSuperuser,
+                                                  forceReinstall: forceReinstall)
                 }
             }
             .recover { error -> Promise<InstalledXcode> in
@@ -386,6 +404,12 @@ struct Xcodes: AsyncParsableCommand {
             .catch { error in
                 Install.processDownloadOrInstall(error: error)
             }
+        }
+
+        private func shouldAttemptSelectionShortcut(installation: XcodeInstaller.InstallationType) -> Bool {
+            guard !forceReinstall else { return false }
+            guard case .version = installation else { return false }
+            return true
         }
     }
 

--- a/Sources/xcodes/App.swift
+++ b/Sources/xcodes/App.swift
@@ -56,14 +56,14 @@ enum InstallArchitectureOption: String, CaseIterable, ExpressibleByArgument {
     case appleSilicon = "apple-silicon"
     case universal
 
-    var requiredArchitectures: [String]? {
+    var requiredArchitectures: Set<XcodeDistributionArchitecture>? {
         switch self {
         case .any:
             return nil
         case .appleSilicon:
-            return ["arm64"]
+            return [.arm64]
         case .universal:
-            return ["arm64", "x86_64"]
+            return [.arm64, .x86_64]
         }
     }
 }

--- a/Tests/XcodesKitTests/XcodeArchitectureSelectionTests.swift
+++ b/Tests/XcodesKitTests/XcodeArchitectureSelectionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Version
+import Path
 @testable import XcodesKit
 
 final class XcodeArchitectureSelectionTests: XCTestCase {
@@ -132,5 +133,54 @@ final class XcodeArchitectureSelectionTests: XCTestCase {
         XCTAssertEqual(architecturesByPath["/Xcode-16-arm64.xip"], [.arm64])
         XCTAssertEqual(architecturesByPath["/Xcode-16-universal.xip"], [.arm64, .x86_64])
         XCTAssertNil(architecturesByPath["/Xcode-legacy.xip"])
+    }
+
+    func test_installedVersionConflict_requiresForceForArchitectureInstall() throws {
+        let version = Version("16.0.0+16A100")!
+        let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-16.0.0.app")!, version: version)
+
+        let error = XcodeInstaller.installedVersionConflict(
+            installedXcode: installedXcode,
+            requiredArchitectures: [.arm64],
+            forceReinstall: false
+        )
+
+        XCTAssertEqual(
+            error,
+            .architectureInstallationRequiresForceReinstall(
+                installedXcode: installedXcode,
+                requiredArchitectures: [.arm64]
+            )
+        )
+    }
+
+    func test_installedVersionConflict_allowsReinstallWithForce() throws {
+        let version = Version("16.0.0+16A100")!
+        let installedXcode = InstalledXcode(path: Path("/Applications/Xcode-16.0.0.app")!, version: version)
+
+        let error = XcodeInstaller.installedVersionConflict(
+            installedXcode: installedXcode,
+            requiredArchitectures: [.arm64],
+            forceReinstall: true
+        )
+
+        XCTAssertNil(error)
+    }
+
+    func test_unavailableXcodeError_returnsArchitectureSpecificError() throws {
+        let version = Version("16.0.0+16A100")!
+
+        let error = XcodeInstaller.unavailableXcodeError(
+            version: version,
+            requiredArchitectures: [.arm64]
+        )
+
+        XCTAssertEqual(
+            error,
+            .unavailableVersionForArchitectures(
+                version: version,
+                requiredArchitectures: [.arm64]
+            )
+        )
     }
 }

--- a/Tests/XcodesKitTests/XcodeArchitectureSelectionTests.swift
+++ b/Tests/XcodesKitTests/XcodeArchitectureSelectionTests.swift
@@ -16,11 +16,11 @@ final class XcodeArchitectureSelectionTests: XCTestCase {
 
         let selected = XcodeInstaller.selectXcodeCandidate(
             version: version,
-            requiredArchitectures: ["arm64"],
+            requiredArchitectures: [.arm64],
             availableXcodes: [universal, appleSilicon],
             architecturesByDownloadPath: [
-                universal.downloadPath: ["arm64", "x86_64"],
-                appleSilicon.downloadPath: ["arm64"]
+                universal.downloadPath: [.arm64, .x86_64],
+                appleSilicon.downloadPath: [.arm64]
             ]
         )
 
@@ -40,11 +40,11 @@ final class XcodeArchitectureSelectionTests: XCTestCase {
 
         let selected = XcodeInstaller.selectXcodeCandidate(
             version: version,
-            requiredArchitectures: ["x86_64", "arm64", "arm64"],
+            requiredArchitectures: [.x86_64, .arm64],
             availableXcodes: [appleSilicon, universal],
             architecturesByDownloadPath: [
-                universal.downloadPath: ["x86_64", "arm64"],
-                appleSilicon.downloadPath: ["arm64"]
+                universal.downloadPath: [.x86_64, .arm64],
+                appleSilicon.downloadPath: [.arm64]
             ]
         )
 
@@ -60,20 +60,28 @@ final class XcodeArchitectureSelectionTests: XCTestCase {
 
         let selected = XcodeInstaller.selectXcodeCandidate(
             version: version,
-            requiredArchitectures: ["arm64"],
+            requiredArchitectures: [.arm64],
             availableXcodes: [universal],
             architecturesByDownloadPath: [
-                universal.downloadPath: ["arm64", "x86_64"]
+                universal.downloadPath: [.arm64, .x86_64]
             ]
         )
 
         XCTAssertNil(selected)
     }
 
-    func test_parseArchitecturesByDownloadPath_normalizesAndFiltersUnsupportedArchitectures() throws {
+    func test_parseXcodeReleasesPayload_normalizesAndFiltersUnsupportedArchitectures() throws {
         let data = """
         [
           {
+            "name": "Xcode 16.0",
+            "version": {
+              "number": "16.0",
+              "build": "16A100",
+              "release": { "release": true }
+            },
+            "date": { "year": 2024, "month": 9, "day": 16 },
+            "requires": "macOS 14.5",
             "links": {
               "download": {
                 "url": "https://example.com/Xcode-16-arm64.xip",
@@ -82,6 +90,14 @@ final class XcodeArchitectureSelectionTests: XCTestCase {
             }
           },
           {
+            "name": "Xcode 16.0",
+            "version": {
+              "number": "16.0",
+              "build": "16A100",
+              "release": { "release": true }
+            },
+            "date": { "year": 2024, "month": 9, "day": 16 },
+            "requires": "macOS 14.5",
             "links": {
               "download": {
                 "url": "https://example.com/Xcode-16-universal.xip",
@@ -90,6 +106,14 @@ final class XcodeArchitectureSelectionTests: XCTestCase {
             }
           },
           {
+            "name": "Xcode 15.4",
+            "version": {
+              "number": "15.4",
+              "build": "15F31",
+              "release": { "release": true }
+            },
+            "date": { "year": 2024, "month": 5, "day": 13 },
+            "requires": "macOS 14.0",
             "links": {
               "download": {
                 "url": "https://example.com/Xcode-legacy.xip",
@@ -101,10 +125,12 @@ final class XcodeArchitectureSelectionTests: XCTestCase {
         """.data(using: .utf8)!
 
         let xcodeList = XcodeList()
-        let architecturesByPath = try xcodeList.parseArchitecturesByDownloadPath(from: data)
+        let payload = try xcodeList.parseXcodeReleasesPayload(from: data)
+        let architecturesByPath = payload.architecturesByDownloadPath
 
-        XCTAssertEqual(architecturesByPath["/Xcode-16-arm64.xip"], ["arm64"])
-        XCTAssertEqual(architecturesByPath["/Xcode-16-universal.xip"], ["arm64", "x86_64"])
+        XCTAssertEqual(payload.xcodes.count, 3)
+        XCTAssertEqual(architecturesByPath["/Xcode-16-arm64.xip"], [.arm64])
+        XCTAssertEqual(architecturesByPath["/Xcode-16-universal.xip"], [.arm64, .x86_64])
         XCTAssertNil(architecturesByPath["/Xcode-legacy.xip"])
     }
 }

--- a/Tests/XcodesKitTests/XcodeArchitectureSelectionTests.swift
+++ b/Tests/XcodesKitTests/XcodeArchitectureSelectionTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import Version
+@testable import XcodesKit
+
+final class XcodeArchitectureSelectionTests: XCTestCase {
+    func test_selectXcodeCandidate_prefersAppleSiliconVariant() throws {
+        let version = Version("16.0.0+16A100")!
+        let universal = Xcode(version: version,
+                              url: URL(string: "https://example.com/Xcode-16-universal.xip")!,
+                              filename: "Xcode-16-universal.xip",
+                              releaseDate: nil)
+        let appleSilicon = Xcode(version: version,
+                                 url: URL(string: "https://example.com/Xcode-16-arm64.xip")!,
+                                 filename: "Xcode-16-arm64.xip",
+                                 releaseDate: nil)
+
+        let selected = XcodeInstaller.selectXcodeCandidate(
+            version: version,
+            requiredArchitectures: ["arm64"],
+            availableXcodes: [universal, appleSilicon],
+            architecturesByDownloadPath: [
+                universal.downloadPath: ["arm64", "x86_64"],
+                appleSilicon.downloadPath: ["arm64"]
+            ]
+        )
+
+        XCTAssertEqual(selected?.url, appleSilicon.url)
+    }
+
+    func test_selectXcodeCandidate_matchesUniversalWithNormalizedArchitectures() throws {
+        let version = Version("16.0.0+16A100")!
+        let universal = Xcode(version: version,
+                              url: URL(string: "https://example.com/Xcode-16-universal.xip")!,
+                              filename: "Xcode-16-universal.xip",
+                              releaseDate: nil)
+        let appleSilicon = Xcode(version: version,
+                                 url: URL(string: "https://example.com/Xcode-16-arm64.xip")!,
+                                 filename: "Xcode-16-arm64.xip",
+                                 releaseDate: nil)
+
+        let selected = XcodeInstaller.selectXcodeCandidate(
+            version: version,
+            requiredArchitectures: ["x86_64", "arm64", "arm64"],
+            availableXcodes: [appleSilicon, universal],
+            architecturesByDownloadPath: [
+                universal.downloadPath: ["x86_64", "arm64"],
+                appleSilicon.downloadPath: ["arm64"]
+            ]
+        )
+
+        XCTAssertEqual(selected?.url, universal.url)
+    }
+
+    func test_selectXcodeCandidate_returnsNilWhenArchitectureVariantMissing() throws {
+        let version = Version("16.0.0+16A100")!
+        let universal = Xcode(version: version,
+                              url: URL(string: "https://example.com/Xcode-16-universal.xip")!,
+                              filename: "Xcode-16-universal.xip",
+                              releaseDate: nil)
+
+        let selected = XcodeInstaller.selectXcodeCandidate(
+            version: version,
+            requiredArchitectures: ["arm64"],
+            availableXcodes: [universal],
+            architecturesByDownloadPath: [
+                universal.downloadPath: ["arm64", "x86_64"]
+            ]
+        )
+
+        XCTAssertNil(selected)
+    }
+
+    func test_parseArchitecturesByDownloadPath_normalizesAndFiltersUnsupportedArchitectures() throws {
+        let data = """
+        [
+          {
+            "links": {
+              "download": {
+                "url": "https://example.com/Xcode-16-arm64.xip",
+                "architectures": ["arm64"]
+              }
+            }
+          },
+          {
+            "links": {
+              "download": {
+                "url": "https://example.com/Xcode-16-universal.xip",
+                "architectures": ["x86_64", "arm64", "x86_64"]
+              }
+            }
+          },
+          {
+            "links": {
+              "download": {
+                "url": "https://example.com/Xcode-legacy.xip",
+                "architectures": ["i386"]
+              }
+            }
+          }
+        ]
+        """.data(using: .utf8)!
+
+        let xcodeList = XcodeList()
+        let architecturesByPath = try xcodeList.parseArchitecturesByDownloadPath(from: data)
+
+        XCTAssertEqual(architecturesByPath["/Xcode-16-arm64.xip"], ["arm64"])
+        XCTAssertEqual(architecturesByPath["/Xcode-16-universal.xip"], ["arm64", "x86_64"])
+        XCTAssertNil(architecturesByPath["/Xcode-legacy.xip"])
+    }
+}

--- a/Tests/XcodesKitTests/XcodeForceReinstallRollbackTests.swift
+++ b/Tests/XcodesKitTests/XcodeForceReinstallRollbackTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+import Foundation
+import Version
+import PromiseKit
+import Path
+@testable import XcodesKit
+
+final class XcodeForceReinstallRollbackTests: XCTestCase {
+    var xcodeInstaller: XcodeInstaller!
+
+    override class func setUp() {
+        super.setUp()
+        PromiseKit.conf.Q.map = nil
+        PromiseKit.conf.Q.return = nil
+    }
+
+    override func setUp() {
+        Current = .mock
+        xcodeInstaller = XcodeInstaller(xcodeList: XcodeList(), sessionService: AppleSessionService(configuration: Configuration()))
+    }
+
+    func test_forceReinstall_restoresPreviousInstallationOnFailure() {
+        let version = Version("26.0.0")!
+        let archivePath = Path("/tmp/Xcode-26.0.0.xip")!
+        let destination = Path("/Applications")!
+        let installedAppPath = destination.join("Xcode-\(version.descriptionWithoutBuildMetadata).app")
+        let expectedError = NSError(domain: "XcodeForceReinstallRollbackTests", code: 420)
+
+        var existingPaths = Set([installedAppPath.string])
+        var moveOperations = [(from: String, to: String)]()
+
+        Current.files.installedXcodes = { _ in
+            [InstalledXcode(path: installedAppPath, version: version)]
+        }
+        Current.files.fileExistsAtPath = { existingPaths.contains($0) }
+        Current.files.moveItem = { source, destination in
+            moveOperations.append((source.path, destination.path))
+            guard existingPaths.contains(source.path) else {
+                throw NSError(domain: "XcodeForceReinstallRollbackTests", code: 100)
+            }
+            existingPaths.remove(source.path)
+            existingPaths.insert(destination.path)
+        }
+        Current.files.removeItem = { url in
+            existingPaths.remove(url.path)
+        }
+        Current.shell.unxip = { _ in
+            Promise(error: expectedError)
+        }
+
+        let expectation = expectation(description: "force reinstall failure restores previous app")
+
+        xcodeInstaller.install(.path(version.appleDescription, archivePath),
+                               dataSource: .xcodeReleases,
+                               downloader: .urlSession,
+                               destination: destination,
+                               emptyTrash: false,
+                               noSuperuser: true,
+                               forceReinstall: true)
+        .done { _ in
+            XCTFail("Expected install to fail.")
+        }
+        .catch { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, expectedError.domain)
+            XCTAssertEqual(nsError.code, expectedError.code)
+
+            XCTAssertEqual(moveOperations.count, 2)
+            XCTAssertEqual(moveOperations.first?.from, installedAppPath.string)
+            XCTAssertEqual(moveOperations.last?.from, moveOperations.first?.to)
+            XCTAssertEqual(moveOperations.last?.to, installedAppPath.string)
+            XCTAssertTrue(existingPaths.contains(installedAppPath.string))
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func test_forceReinstall_cleansBackupOnSuccess() {
+        let version = Version("26.0.0")!
+        let archivePath = Path("/tmp/Xcode-26.0.0.xip")!
+        let unpackedAppPath = Path("/tmp/Xcode.app")!
+        let destination = Path("/Applications")!
+        let installedAppPath = destination.join("Xcode-\(version.descriptionWithoutBuildMetadata).app")
+        let installedXcode = InstalledXcode(path: installedAppPath, version: version)
+
+        var existingPaths = Set([installedAppPath.string, archivePath.string, unpackedAppPath.string])
+        var moveOperations = [(from: String, to: String)]()
+        var trashedPaths = [String]()
+
+        Current.files.installedXcodes = { _ in
+            [InstalledXcode(path: installedAppPath, version: version)]
+        }
+        Current.files.fileExistsAtPath = { existingPaths.contains($0) }
+        Current.files.moveItem = { source, destination in
+            moveOperations.append((source.path, destination.path))
+            guard existingPaths.contains(source.path) else {
+                throw NSError(domain: "XcodeForceReinstallRollbackTests", code: 101)
+            }
+            existingPaths.remove(source.path)
+            existingPaths.insert(destination.path)
+        }
+        Current.files.trashItem = { url in
+            trashedPaths.append(url.path)
+            existingPaths.remove(url.path)
+            return URL(fileURLWithPath: "/tmp/.Trash/\(url.lastPathComponent)")
+        }
+        Current.shell.unxip = { _ in
+            Promise.value(Shell.processOutputMock)
+        }
+        Current.shell.codesignVerify = { _ in
+            Promise.value(
+                ProcessOutput(
+                    status: 0,
+                    out: "",
+                    err: """
+                        TeamIdentifier=\(XcodeInstaller.XcodeTeamIdentifier)
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[0])
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[1])
+                        Authority=\(XcodeInstaller.XcodeCertificateAuthority[2])
+                        """
+                )
+            )
+        }
+
+        let expectation = expectation(description: "force reinstall success cleans backup")
+
+        xcodeInstaller.install(.path(version.appleDescription, archivePath),
+                               dataSource: .xcodeReleases,
+                               downloader: .urlSession,
+                               destination: destination,
+                               emptyTrash: false,
+                               noSuperuser: true,
+                               forceReinstall: true)
+        .done { result in
+            XCTAssertEqual(result.path, installedXcode.path)
+
+            XCTAssertEqual(moveOperations.count, 2)
+            XCTAssertEqual(moveOperations[0].from, installedAppPath.string)
+            XCTAssertEqual(moveOperations[1].from, unpackedAppPath.string)
+            XCTAssertEqual(moveOperations[1].to, installedAppPath.string)
+
+            let backupPath = moveOperations[0].to
+            XCTAssertEqual(Set(trashedPaths), Set([archivePath.string, backupPath]))
+            XCTAssertTrue(existingPaths.contains(installedAppPath.string))
+            XCTAssertFalse(existingPaths.contains(backupPath))
+            expectation.fulfill()
+        }
+        .catch { error in
+            XCTFail("Expected install to succeed, got \(error)")
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+}

--- a/Tests/xcodesTests/xcodesTests.swift
+++ b/Tests/xcodesTests/xcodesTests.swift
@@ -1,33 +1,34 @@
 import XCTest
 import class Foundation.Bundle
+import Foundation
 
 final class xcodesTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
+    struct ProcessResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+    }
 
-        // Some of the APIs that we use below are available in macOS 10.13 and above.
-        // guard #available(macOS 10.13, *) else {
-        //     return
-        // }
+    func test_installArchitecture_requiresExplicitVersion() throws {
+        let result = try runXcodes(["install", "--latest", "--architecture", "apple-silicon", "--no-color"])
 
-        // let fooBinary = productsDirectory.appendingPathComponent("xcodes")
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.stdout.contains("--architecture is currently supported only when installing an explicit Xcode version."))
+    }
 
-        // let process = Process()
-        // process.executableURL = fooBinary
-        // process.arguments = ["--help"]
+    func test_installArchitecture_requiresXcodeReleasesDataSource_evenWithForceReinstall() throws {
+        let result = try runXcodes(["install", "26.0", "--architecture", "apple-silicon", "--force-reinstall", "--data-source", "apple", "--no-color"])
 
-        // let pipe = Pipe()
-        // process.standardOutput = pipe
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.stdout.contains("--architecture requires --data-source xcodeReleases, but got apple."))
+    }
 
-        // try process.run()
-        // process.waitUntilExit()
+    func test_installHelp_containsArchitectureAndForceReinstallFlags() throws {
+        let result = try runXcodes(["install", "--help"])
 
-        // let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        // let output = String(data: data, encoding: .utf8)
-
-        // XCTAssertNotNil(output)
+        XCTAssertEqual(result.status, 0)
+        XCTAssertTrue(result.stdout.contains("--architecture"))
+        XCTAssertTrue(result.stdout.contains("--force-reinstall"))
     }
 
     /// Returns path to the built products directory.
@@ -40,5 +41,32 @@ final class xcodesTests: XCTestCase {
       #else
         return Bundle.main.bundleURL
       #endif
+    }
+
+    private func runXcodes(_ arguments: [String]) throws -> ProcessResult {
+        let process = Process()
+        process.executableURL = productsDirectory.appendingPathComponent("xcodes")
+        process.arguments = arguments
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["NO_COLOR"] = "1"
+        process.environment = environment
+
+        let standardOutputPipe = Pipe()
+        let standardErrorPipe = Pipe()
+        process.standardOutput = standardOutputPipe
+        process.standardError = standardErrorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutData = standardOutputPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = standardErrorPipe.fileHandleForReading.readDataToEndOfFile()
+
+        return ProcessResult(
+            status: process.terminationStatus,
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? ""
+        )
     }
 }


### PR DESCRIPTION
## Introduction

This PR adds architecture-aware Xcode installation to the CLI and hardens reinstall behavior to avoid leaving users without a working Xcode when installation fails.

## Motivation

The GUI already supports choosing architecture variants (Apple Silicon vs Universal), while CLI installs were version-only.
Earlier revision of this branch removed the existing app before installation; this PR makes force-reinstall transactional with backup/restore.

## Proposed solution

- Add `--architecture` to `xcodes install`:
  - `any` (default)
  - `apple-silicon` (`arm64`)
  - `universal` (`arm64,x86_64`)
- Support architecture selection only for explicit version installs.
- Require `--data-source xcodeReleases` for non-default architecture selection.
- Add `--force-reinstall` to allow reinstall when the same version is already installed.
- Add explicit architecture-related errors:
  - unavailable version for requested architecture set
  - architecture reinstall requires `--force-reinstall`
- Parse `architectures` metadata from xcodereleases payload.
- Select download candidate by exact architecture set match.
- Implement safe force-reinstall rollback:
  - move existing `Xcode-<version>.app` to a temporary backup
  - restore backup on install failure
  - cleanup backup on success

## Detailed design

- `XcodeList`:
  - parse xcodereleases payload into `(xcodes, architecturesByDownloadPath)`
  - normalize architecture strings into typed enum values

- `XcodeInstaller`:
  - introduce `InstallationType.versionWithArchitectures`
  - centralize installed-version conflict policy
  - select candidates using architecture map
  - add transactional rollback wrapper for force reinstall

- CLI (`xcodes install`):
  - new flags: `--architecture`, `--force-reinstall`
  - validation:
  - `--architecture` requires explicit version
  - `--architecture != any` requires `--data-source xcodeReleases`

## Compatibility

- Existing behavior is unchanged when `--architecture` is omitted (or `any`).
- Existing install modes (`--latest`, `--latest-prerelease`, `--path`) remain supported.
- New validations fail fast with clear user-facing errors.

## Testing

Added/updated tests:
- `XcodeArchitectureSelectionTests`
  - architecture candidate selection
  - payload normalization
  - conflict/error behavior
- `XcodeForceReinstallRollbackTests`
  - backup restore on failure
  - backup cleanup on success
- `xcodesTests` (CLI integration)
  - architecture validation errors
  - install help includes new flags

Validation:
- `swift test` passes (`88` tests, `0` failures).

## Non-goals

- No changes to download provider behavior beyond architecture filtering.
- No broader refactor of install/network/session pipelines.
