### PR TITLE
fix: correct typos in comments and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _If you're looking for an app version of `xcodes`, try [Xcodes.app](https://gith
 
 ![Header Image](Header.png)
 
-### :tada: Announcment
+### :tada: Announcement
 
 Xcodes is now part of the `XcodesOrg` - [read more here](nextstep.md)
 

--- a/Sources/XcodesKit/RuntimeInstaller.swift
+++ b/Sources/XcodesKit/RuntimeInstaller.swift
@@ -430,7 +430,7 @@ private extension Progress {
     func updateFromXcodebuild(text: String) {
         self.totalUnitCount = 100
         self.completedUnitCount = 0
-        self.localizedAdditionalDescription = "" // to not show the addtional
+        self.localizedAdditionalDescription = "" // to not show the additional
 
         do {
 

--- a/Sources/XcodesKit/URLSession+Promise.swift
+++ b/Sources/XcodesKit/URLSession+Promise.swift
@@ -5,7 +5,7 @@ import PMKFoundation
 extension URLSession {
     /**
      - Parameter convertible: A URL or URLRequest.
-     - Parameter saveLocation: A URL to move the downloaded file to after it completes. Apple deletes the temporary file immediately after the underyling completion handler returns.
+     - Parameter saveLocation: A URL to move the downloaded file to after it completes. Apple deletes the temporary file immediately after the underlying completion handler returns.
      - Parameter resumeData: Data describing the state of a previously cancelled or failed download task. See the Discussion section for `downloadTask(withResumeData:completionHandler:)` https://developer.apple.com/documentation/foundation/urlsession/1411598-downloadtask#
 
      - Returns: Tuple containing a Progress object for the task and a promise containing the save location and response.

--- a/Sources/XcodesKit/Version+Xcode.swift
+++ b/Sources/XcodesKit/Version+Xcode.swift
@@ -58,7 +58,7 @@ public extension Version {
         self = Version(major: major, minor: minor, patch: patch, prereleaseIdentifiers: prereleaseIdentifiers, buildMetadataIdentifiers: [buildMetadataIdentifier].compactMap { $0 })
     }
 
-    /// Attempt to instatiate a `Version` using the `.xcode-version` file in the provided directory
+    /// Attempt to instantiate a `Version` using the `.xcode-version` file in the provided directory
     static func fromXcodeVersionFile(inDirectory: Path = Path.cwd) -> Version? {
         let xcodeVersionFilePath = inDirectory.join(".xcode-version")
         guard

--- a/nextstep.md
+++ b/nextstep.md
@@ -4,7 +4,7 @@ As Xcodes continues to grow beyond a small little utility used by Apple Develope
 
 Starting April 21, 2023, all Xcodes repos are now contained under the `XcodesOrg` organization.  https://github.com/XcodesOrg 
 
-This change will have no effect on the tools at all, but allows the utilites to grow to the next level. I'm (Matt Kiazyk) still the owner and current sole maintainer, and have no plans to stop. 
+This change will have no effect on the tools at all, but allows the utilities to grow to the next level. I'm (Matt Kiazyk) still the owner and current sole maintainer, and have no plans to stop. 
 
 Xcodes would not be where it is without contributors over the years. It would also not be where it is without each and every one of you sharing the tool. 
 


### PR DESCRIPTION
## Summary

Fix several typos in documentation and source comments.

## Changes

- Correct `Announcment` to `Announcement` in README
- Correct `utilites` to `utilities` in nextstep.md
- Correct typos in Swift comments:
  - `addtional` → `additional`
  - `underyling` → `underlying`
  - `instatiate` → `instantiate`

## Testing

Not run; comment/documentation-only changes.